### PR TITLE
Move contract storage to TreeMap from nested UnorderedMap 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,10 +4,6 @@
 name = "Inflector"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "actix"
@@ -1910,7 +1906,7 @@ dependencies = [
  "near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
  "near-jsonrpc-client 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
  "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-sdk 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "near-sdk 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-bytes 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2109,14 +2105,6 @@ dependencies = [
 
 [[package]]
 name = "near-runtime-fees"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "near-runtime-fees"
 version = "0.9.0"
 source = "git+https://github.com/nearprotocol/nearcore#442998a79b9f9556c94aec2174eb858b31c0b4ee"
 dependencies = [
@@ -2125,22 +2113,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "near-runtime-fees"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-rational 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "near-sdk"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "borsh 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-runtime-fees 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-sdk-macros 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-vm-logic 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "near-runtime-fees 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "near-sdk-macros 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "near-vm-logic 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "near-sdk-core"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "Inflector 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2151,10 +2148,10 @@ dependencies = [
 
 [[package]]
 name = "near-sdk-macros"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "near-sdk-core 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "near-sdk-core 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2196,16 +2193,6 @@ dependencies = [
 
 [[package]]
 name = "near-vm-errors"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "borsh 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-rpc-error-macro 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "near-vm-errors"
 version = "0.9.0"
 source = "git+https://github.com/nearprotocol/nearcore#442998a79b9f9556c94aec2174eb858b31c0b4ee"
 dependencies = [
@@ -2215,18 +2202,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-vm-logic"
-version = "0.8.0"
+name = "near-vm-errors"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bs58 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-runtime-fees 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-vm-errors 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "near-rpc-error-macro 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2239,6 +2221,21 @@ dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "near-runtime-fees 0.9.0 (git+https://github.com/nearprotocol/nearcore)",
  "near-vm-errors 0.9.0 (git+https://github.com/nearprotocol/nearcore)",
+ "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "near-vm-logic"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bs58 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "near-runtime-fees 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "near-vm-errors 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4103,17 +4100,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum near-rpc-error-macro 0.1.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
 "checksum near-rpc-error-macro 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0c6111d713e90c7c551dee937f4a06cb9ea2672243455a4454cc7566387ba2d9"
 "checksum near-runtime-configs 0.1.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
-"checksum near-runtime-fees 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4324fa778de675b23edb4da36eac17a05ef7fc40f0a6d36e83cc6040e56fdb30"
 "checksum near-runtime-fees 0.9.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
-"checksum near-sdk 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fdd218ef5ff9acf4ed8375c14aac570589ec837a05d61b60a2e3d212d4358a90"
-"checksum near-sdk-core 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "88f97b569352978bc6473f928459ce6f3d040a465b8d087097c6cd038e9dc65d"
-"checksum near-sdk-macros 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "52b152b7e4821601ae363aa088a9f0b76b120c666b5b6a07aa395fa9a1279a49"
+"checksum near-runtime-fees 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8f4992274c8acb33fa1246715d3aafbce5688ae82243c779b561f8eaff1bb6f1"
+"checksum near-sdk 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "81319d4d44283f63467e4f02b6209297b10643c7aeb62e2ee41e0c31b43e2375"
+"checksum near-sdk-core 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f3767fc2a61e6577f1336e06d6962a6c61fc39299573b8a25696fd09ce96ffb"
+"checksum near-sdk-macros 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "27c06b45c56028b0e1241b2196397d449091665f3f08d543415373505df5e05f"
 "checksum near-store 0.1.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
 "checksum near-telemetry 0.1.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
-"checksum near-vm-errors 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "464d6d36cf4840bed8ef57a4f043ce1da471b7021171d5470bd9f3112611fe9a"
 "checksum near-vm-errors 0.9.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
-"checksum near-vm-logic 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dd3b537fe6c7b0eada25747c6bd3a3de26f572f5ee84c72fda054f715b83e281"
+"checksum near-vm-errors 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "386c2c07ef37ae52ad43860ef69c6322bbc1e610ae0c08c1d7f5ff56f4c28e6a"
 "checksum near-vm-logic 0.9.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
+"checksum near-vm-logic 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a6da6c80d3428f45248577820bfc943b8261a6f11d6721037e5c3f43484047cd"
 "checksum near-vm-runner 0.9.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
 "checksum neard 0.4.13 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
 "checksum net2 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)" = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ ethereum-types = "0.6.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 hex = "0.3.2"
-near-sdk = "0.9.2"
+near-sdk = "0.11.0"
 borsh = "0.6.0"
 rlp = "0.4.2"
 keccak-hash = "0.2.0"

--- a/src/evm_state.rs
+++ b/src/evm_state.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use ethereum_types::{Address, U256};
 
@@ -42,13 +42,21 @@ pub trait EvmState {
         nonce
     }
 
-    fn read_contract_storage(&self, address: &Address, key: [u8; 32]) -> Option<[u8; 32]>;
+    fn _read_contract_storage(&self, key: [u8; 52]) -> Option<[u8; 32]>;
+    fn read_contract_storage(&self, address: &Address, key: [u8; 32]) -> Option<[u8; 32]> {
+        self._read_contract_storage(utils::internal_storage_key(address, key))
+    }
+
+    fn _set_contract_storage(&mut self, key: [u8; 52], value: [u8; 32]) -> Option<[u8; 32]>;
+
     fn set_contract_storage(
         &mut self,
         address: &Address,
         key: [u8; 32],
         value: [u8; 32],
-    ) -> Option<[u8; 32]>;
+    ) -> Option<[u8; 32]> {
+        self._set_contract_storage(utils::internal_storage_key(address, key), value)
+    }
 
     fn commit_changes(&mut self, other: &StateStore);
 
@@ -83,58 +91,70 @@ pub struct StateStore {
     pub code: HashMap<[u8; 20], Vec<u8>>,
     pub balances: HashMap<[u8; 20], [u8; 32]>,
     pub nonces: HashMap<[u8; 20], [u8; 32]>,
-    pub storages: HashMap<[u8; 20], HashMap<[u8; 32], [u8; 32]>>,
+    pub storages: BTreeMap<Vec<u8>, [u8; 32]>,
     pub logs: Vec<String>,
+    pub self_destructs: HashSet<[u8; 20]>,
+    pub recreated: HashSet<[u8; 20]>,
 }
 
 impl StateStore {
-    pub fn commit_code(&mut self, other: &HashMap<[u8; 20], Vec<u8>>) {
-        self.code
-            .extend(other.iter().map(|(k, v)| (*k, v.clone())));
-    }
+    fn overwrite_storage(&mut self, addr: [u8; 20]) {
+        let address_key = addr.to_vec();
+        let mut next_address_key = address_key.clone();
+        *(next_address_key.last_mut().unwrap()) += 1;
 
-    pub fn commit_balances(&mut self, other: &HashMap<[u8; 20], [u8; 32]>) {
-        self.balances
-            .extend(other.iter().map(|(k, v)| (*k, *v)));
-    }
+        let range = (
+            std::ops::Bound::Excluded(address_key),
+            std::ops::Bound::Excluded(next_address_key),
+        );
 
-    pub fn commit_nonces(&mut self, other: &HashMap<[u8; 20], [u8; 32]>) {
-        self.nonces
-            .extend(other.iter().map(|(k, v)| (*k, *v)));
-    }
-
-    pub fn commit_storages(&mut self, other: &HashMap<[u8; 20], HashMap<[u8; 32], [u8; 32]>>) {
-        for (k, v) in other.iter() {
-            match self.storages.get_mut(k) {
-                Some(contract_storage) => {
-                    contract_storage.extend(v.iter().map(|(k, v)| (*k, *v)))
-                }
-                None => {
-                    self.storages.insert(*k, v.clone());
-                }
-            }
+        let keys: Vec<_> = self.storages.range(range).map(|(k, _)| k.clone()).collect();
+        for k in keys.iter() {
+            self.storages.remove(k);
         }
     }
 
-    pub fn contract_storage(&self, address: [u8; 20]) -> Option<&HashMap<[u8; 32], [u8; 32]>> {
-        self.storages.get(&address)
+    pub fn recreate(&mut self, addr: [u8; 20]) {
+        self.code.remove(&addr);
+        // We do not delete balance here, as balances persist across recreation
+        self.nonces.remove(&addr);
+        self.overwrite_storage(addr);
+        self.self_destructs.remove(&addr);
+        self.recreated.insert(addr);
     }
 
-    pub fn mut_contract_storage(&mut self, address: [u8; 20]) -> &mut HashMap<[u8; 32], [u8; 32]> {
-        self
-            .storages
-            .entry(address)
-            .or_insert_with(Default::default)
+    pub fn commit_code(&mut self, other: &HashMap<[u8; 20], Vec<u8>>) {
+        self.code.extend(other.iter().map(|(k, v)| (*k, v.clone())));
+    }
+
+    pub fn commit_balances(&mut self, other: &HashMap<[u8; 20], [u8; 32]>) {
+        self.balances.extend(other.iter().map(|(k, v)| (*k, *v)));
+    }
+
+    pub fn commit_nonces(&mut self, other: &HashMap<[u8; 20], [u8; 32]>) {
+        self.nonces.extend(other.iter().map(|(k, v)| (*k, *v)));
+    }
+
+    pub fn commit_storages(&mut self, other: &BTreeMap<Vec<u8>, [u8; 32]>) {
+        self.storages
+            .extend(other.iter().map(|(k, v)| (k.clone(), *v)))
+    }
+
+    pub fn commit_self_destructs(&mut self, other: &HashSet<[u8; 20]>) {
+        self.self_destructs.extend(other);
+    }
+
+    pub fn commit_recreated(&mut self, other: &HashSet<[u8; 20]>) {
+        self.recreated.extend(other);
     }
 }
 
 impl EvmState for StateStore {
     fn code_at(&self, address: &Address) -> Option<Vec<u8>> {
         let internal_addr = utils::evm_account_to_internal_address(*address);
-        self
-            .code
-            .get(&internal_addr)
-            .cloned()
+        if self.self_destructs.contains(&internal_addr) { None } else {
+            self.code.get(&internal_addr).cloned()
+        }
     }
 
     fn set_code(&mut self, address: &Address, bytecode: &[u8]) {
@@ -143,11 +163,7 @@ impl EvmState for StateStore {
     }
 
     fn _balance_of(&self, address: [u8; 20]) -> [u8; 32] {
-        self
-            .balances
-            .get(&address)
-            .copied()
-            .unwrap_or([0u8; 32])
+        self.balances.get(&address).copied().unwrap_or([0u8; 32])
     }
 
     fn _set_balance(&mut self, address: [u8; 20], balance: [u8; 32]) -> Option<[u8; 32]> {
@@ -155,35 +171,35 @@ impl EvmState for StateStore {
     }
 
     fn _nonce_of(&self, address: [u8; 20]) -> [u8; 32] {
-        self
-            .nonces
-            .get(&address)
-            .copied()
-            .unwrap_or([0u8; 32])
+        let empty = [0u8; 32];
+        if self.self_destructs.contains(&address) {
+            empty
+        } else {
+            self.nonces.get(&address).copied().unwrap_or(empty)
+        }
     }
 
     fn _set_nonce(&mut self, address: [u8; 20], nonce: [u8; 32]) -> Option<[u8; 32]> {
         self.nonces.insert(address, nonce)
     }
 
-    fn read_contract_storage(&self, address: &Address, key: [u8; 32]) -> Option<[u8; 32]> {
-        let internal_addr = utils::evm_account_to_internal_address(*address);
-        self.contract_storage(internal_addr).map(
-            |s| s.get(&key).copied(),
-        ).flatten()
+    fn _read_contract_storage(&self, key: [u8; 52]) -> Option<[u8; 32]> {
+        let mut addr = [0u8; 20];
+        addr.copy_from_slice(&key[..20]);
+        if self.self_destructs.contains(&addr) {
+            None
+        } else {
+            self.storages.get(&key.to_vec()).cloned()
+        }
     }
 
-    fn set_contract_storage(
-        &mut self,
-        address: &Address,
-        key: [u8; 32],
-        value: [u8; 32],
-    ) -> Option<[u8; 32]> {
-        let internal_addr = utils::evm_account_to_internal_address(*address);
-        self.mut_contract_storage(internal_addr).insert(key, value)
+    fn _set_contract_storage(&mut self, key: [u8; 52], value: [u8; 32]) -> Option<[u8; 32]> {
+        self.storages.insert(key.to_vec(), value)
     }
 
     fn commit_changes(&mut self, other: &StateStore) {
+        self.commit_self_destructs(&other.self_destructs);
+        self.commit_recreated(&other.recreated);
         self.commit_code(&other.code);
         self.commit_balances(&other.balances);
         self.commit_nonces(&other.nonces);
@@ -210,26 +226,17 @@ impl SubState<'_> {
             parent,
         }
     }
-
-    pub fn contract_storage(&self, address: [u8; 20]) -> Option<&HashMap<[u8; 32], [u8; 32]>> {
-        self.state.storages.get(&address)
-    }
-
-    pub fn mut_contract_storage(&mut self, address: [u8; 20]) -> &mut HashMap<[u8; 32], [u8; 32]> {
-        self.state
-            .storages
-            .entry(address)
-            .or_insert_with(Default::default)
-    }
 }
 
 impl EvmState for SubState<'_> {
     fn code_at(&self, address: &Address) -> Option<Vec<u8>> {
         let internal_addr = utils::evm_account_to_internal_address(*address);
-        self.state
-            .code
-            .get(&internal_addr)
-            .map_or_else(|| self.parent.code_at(address), |k| Some(k.to_vec()))
+        if self.state.self_destructs.contains(&internal_addr) { None } else {
+            self.state
+                .code
+                .get(&internal_addr)
+                .map_or_else(|| self.parent.code_at(address), |k| Some(k.to_vec()))
+        }
     }
 
     fn set_code(&mut self, address: &Address, bytecode: &[u8]) {
@@ -249,35 +256,43 @@ impl EvmState for SubState<'_> {
     }
 
     fn _nonce_of(&self, address: [u8; 20]) -> [u8; 32] {
-        self.state
-            .nonces
-            .get(&address)
-            .map_or_else(|| self.parent._nonce_of(address), |k| *k)
+        let empty = [0u8; 32];
+        if self.state.self_destructs.contains(&address) {
+            empty
+        } else {
+            self.state
+                .nonces
+                .get(&address)
+                .map_or_else(|| self.parent._nonce_of(address), |k| *k)
+
+        }
     }
 
     fn _set_nonce(&mut self, address: [u8; 20], nonce: [u8; 32]) -> Option<[u8; 32]> {
         self.state.nonces.insert(address, nonce)
     }
 
-    fn read_contract_storage(&self, address: &Address, key: [u8; 32]) -> Option<[u8; 32]> {
-        let internal_addr = utils::evm_account_to_internal_address(*address);
-        self.contract_storage(internal_addr).map_or_else(
-            || self.parent.read_contract_storage(address, key),
-            |s| s.get(&key).copied(),
-        )
+    fn _read_contract_storage(&self, key: [u8; 52]) -> Option<[u8; 32]> {
+        let mut addr = [0u8; 20];
+        addr.copy_from_slice(&key[..20]);
+        if self.state.self_destructs.contains(&addr) {
+            None
+        } else {
+            self.state
+                .storages
+                .get(&key.to_vec())
+                .copied()
+                .or_else(|| self.parent._read_contract_storage(key))
+        }
     }
 
-    fn set_contract_storage(
-        &mut self,
-        address: &Address,
-        key: [u8; 32],
-        value: [u8; 32],
-    ) -> Option<[u8; 32]> {
-        let internal_addr = utils::evm_account_to_internal_address(*address);
-        self.mut_contract_storage(internal_addr).insert(key, value)
+    fn _set_contract_storage(&mut self, key: [u8; 52], value: [u8; 32]) -> Option<[u8; 32]> {
+        self.state.storages.insert(key.to_vec(), value)
     }
 
     fn commit_changes(&mut self, other: &StateStore) {
+        self.state.commit_self_destructs(&other.self_destructs);
+        self.state.commit_recreated(&other.recreated);
         self.state.commit_code(&other.code);
         self.state.commit_balances(&other.balances);
         self.state.commit_nonces(&other.nonces);
@@ -324,47 +339,74 @@ mod test {
         assert_eq!(top.balance_of(&addr_2), zero);
 
         top.set_contract_storage(&addr_0, storage_key_0, storage_value_0);
-        assert_eq!(top.read_contract_storage(&addr_0, storage_key_0), Some(storage_value_0));
+        assert_eq!(
+            top.read_contract_storage(&addr_0, storage_key_0),
+            Some(storage_value_0)
+        );
         assert_eq!(top.read_contract_storage(&addr_1, storage_key_0), None);
         assert_eq!(top.read_contract_storage(&addr_2, storage_key_0), None);
 
         let next = {
             // Open a new store
             let mut next = StateStore::default();
-            let mut sub1 = SubState::new(&addr_0, &mut next, &mut top);
+            let mut sub_1 = SubState::new(&addr_0, &mut next, &mut top);
 
-            sub1.set_code(&addr_1, &code);
-            assert_eq!(sub1.code_at(&addr_0), Some(code.to_vec()));
-            assert_eq!(sub1.code_at(&addr_1), Some(code.to_vec()));
-            assert_eq!(sub1.code_at(&addr_2), None);
+            sub_1.set_code(&addr_1, &code);
+            assert_eq!(sub_1.code_at(&addr_0), Some(code.to_vec()));
+            assert_eq!(sub_1.code_at(&addr_1), Some(code.to_vec()));
+            assert_eq!(sub_1.code_at(&addr_2), None);
 
-            sub1.set_nonce(&addr_1, nonce);
-            assert_eq!(sub1.nonce_of(&addr_0), nonce);
-            assert_eq!(sub1.nonce_of(&addr_1), nonce);
-            assert_eq!(sub1.nonce_of(&addr_2), zero);
+            sub_1.set_nonce(&addr_1, nonce);
+            assert_eq!(sub_1.nonce_of(&addr_0), nonce);
+            assert_eq!(sub_1.nonce_of(&addr_1), nonce);
+            assert_eq!(sub_1.nonce_of(&addr_2), zero);
 
-            sub1.set_balance(&addr_1, balance);
-            assert_eq!(sub1.balance_of(&addr_0), balance);
-            assert_eq!(sub1.balance_of(&addr_1), balance);
-            assert_eq!(sub1.balance_of(&addr_2), zero);
+            sub_1.set_balance(&addr_1, balance);
+            assert_eq!(sub_1.balance_of(&addr_0), balance);
+            assert_eq!(sub_1.balance_of(&addr_1), balance);
+            assert_eq!(sub_1.balance_of(&addr_2), zero);
 
-            sub1.set_contract_storage(&addr_1, storage_key_0, storage_value_0);
-            assert_eq!(sub1.read_contract_storage(&addr_0, storage_key_0), Some(storage_value_0));
-            assert_eq!(sub1.read_contract_storage(&addr_1, storage_key_0), Some(storage_value_0));
-            assert_eq!(sub1.read_contract_storage(&addr_2, storage_key_0), None);
+            sub_1.set_contract_storage(&addr_1, storage_key_0, storage_value_0);
+            assert_eq!(
+                sub_1.read_contract_storage(&addr_0, storage_key_0),
+                Some(storage_value_0)
+            );
+            assert_eq!(
+                sub_1.read_contract_storage(&addr_1, storage_key_0),
+                Some(storage_value_0)
+            );
+            assert_eq!(sub_1.read_contract_storage(&addr_2, storage_key_0), None);
 
-            sub1.set_contract_storage(&addr_1, storage_key_0, storage_value_1);
-            assert_eq!(sub1.read_contract_storage(&addr_0, storage_key_0), Some(storage_value_0));
-            assert_eq!(sub1.read_contract_storage(&addr_1, storage_key_0), Some(storage_value_1));
-            assert_eq!(sub1.read_contract_storage(&addr_2, storage_key_0), None);
+            sub_1.set_contract_storage(&addr_1, storage_key_0, storage_value_1);
+            assert_eq!(
+                sub_1.read_contract_storage(&addr_0, storage_key_0),
+                Some(storage_value_0)
+            );
+            assert_eq!(
+                sub_1.read_contract_storage(&addr_1, storage_key_0),
+                Some(storage_value_1)
+            );
+            assert_eq!(sub_1.read_contract_storage(&addr_2, storage_key_0), None);
 
-            sub1.set_contract_storage(&addr_1, storage_key_1, storage_value_1);
-            assert_eq!(sub1.read_contract_storage(&addr_1, storage_key_0), Some(storage_value_1));
-            assert_eq!(sub1.read_contract_storage(&addr_1, storage_key_1), Some(storage_value_1));
+            sub_1.set_contract_storage(&addr_1, storage_key_1, storage_value_1);
+            assert_eq!(
+                sub_1.read_contract_storage(&addr_1, storage_key_0),
+                Some(storage_value_1)
+            );
+            assert_eq!(
+                sub_1.read_contract_storage(&addr_1, storage_key_1),
+                Some(storage_value_1)
+            );
 
-            sub1.set_contract_storage(&addr_1, storage_key_0, storage_value_0);
-            assert_eq!(sub1.read_contract_storage(&addr_1, storage_key_0), Some(storage_value_0));
-            assert_eq!(sub1.read_contract_storage(&addr_1, storage_key_1), Some(storage_value_1));
+            sub_1.set_contract_storage(&addr_1, storage_key_0, storage_value_0);
+            assert_eq!(
+                sub_1.read_contract_storage(&addr_1, storage_key_0),
+                Some(storage_value_0)
+            );
+            assert_eq!(
+                sub_1.read_contract_storage(&addr_1, storage_key_1),
+                Some(storage_value_1)
+            );
 
             next
         };
@@ -379,9 +421,111 @@ mod test {
         assert_eq!(top.balance_of(&addr_0), balance);
         assert_eq!(top.balance_of(&addr_1), balance);
         assert_eq!(top.balance_of(&addr_2), zero);
-        assert_eq!(top.read_contract_storage(&addr_0, storage_key_0), Some(storage_value_0));
-        assert_eq!(top.read_contract_storage(&addr_1, storage_key_0), Some(storage_value_0));
-        assert_eq!(top.read_contract_storage(&addr_1, storage_key_1), Some(storage_value_1));
+        assert_eq!(
+            top.read_contract_storage(&addr_0, storage_key_0),
+            Some(storage_value_0)
+        );
+        assert_eq!(
+            top.read_contract_storage(&addr_1, storage_key_0),
+            Some(storage_value_0)
+        );
+        assert_eq!(
+            top.read_contract_storage(&addr_1, storage_key_1),
+            Some(storage_value_1)
+        );
         assert_eq!(top.read_contract_storage(&addr_2, storage_key_0), None);
+    }
+
+    #[test]
+    fn self_destruct_tests() {
+        let addr_0 = Address::repeat_byte(0);
+        let addr_1 = Address::repeat_byte(1);
+        let zero = U256::zero();
+        let code: [u8; 3] = [0, 1, 2];
+        let nonce = U256::from_dec_str("103030303").unwrap();
+        let balance_0 = U256::from_dec_str("3838209").unwrap();
+        let balance_1 = U256::from_dec_str("11223344").unwrap();
+        let storage_key_0 = [4u8; 32];
+        let storage_key_1 = [5u8; 32];
+        let storage_value_0 = [6u8; 32];
+        let storage_value_1 = [7u8; 32];
+
+        // Create the top-level store
+        let mut top = StateStore::default();
+
+        top.set_code(&addr_0, &code);
+        top.set_nonce(&addr_0, nonce);
+        top.set_balance(&addr_0, balance_0);
+        top.set_contract_storage(&addr_0, storage_key_0, storage_value_0);
+
+        top.set_code(&addr_1, &code);
+        top.set_nonce(&addr_1, nonce);
+        top.set_balance(&addr_1, balance_0);
+        top.set_contract_storage(&addr_1, storage_key_1, storage_value_1);
+
+        assert_eq!(top.code_at(&addr_0), Some(code.to_vec()));
+        assert_eq!(top.code_at(&addr_1), Some(code.to_vec()));
+
+        assert_eq!(top.nonce_of(&addr_0), nonce);
+        assert_eq!(top.nonce_of(&addr_1), nonce);
+
+        assert_eq!(top.balance_of(&addr_0), balance_0);
+        assert_eq!(top.balance_of(&addr_1), balance_0);
+
+        assert_eq!(
+            top.read_contract_storage(&addr_0, storage_key_0),
+            Some(storage_value_0)
+        );
+        assert_eq!(
+            top.read_contract_storage(&addr_1, storage_key_1),
+            Some(storage_value_1)
+        );
+
+        let next = {
+            // Open a new store
+            let mut next = StateStore::default();
+            let mut sub_1 = SubState::new(&addr_0, &mut next, &mut top);
+
+            assert_eq!(sub_1.code_at(&addr_1), Some(code.to_vec()));
+            assert_eq!(sub_1.nonce_of(&addr_1), nonce);
+            assert_eq!(sub_1.balance_of(&addr_1), balance_0);
+            assert_eq!(
+                sub_1.read_contract_storage(&addr_1, storage_key_1),
+                Some(storage_value_1)
+            );
+
+            sub_1.state.self_destructs.insert(addr_1.0);
+            sub_1.set_balance(&addr_1, balance_1);
+
+            assert_eq!(sub_1.code_at(&addr_1), None);
+            assert_eq!(sub_1.nonce_of(&addr_1), zero);
+            assert_eq!(sub_1.balance_of(&addr_1), balance_1);
+            assert_eq!(
+                sub_1.read_contract_storage(&addr_1, storage_key_1),
+                None
+            );
+
+            next
+        };
+
+        top.commit_changes(&next);
+
+        assert_eq!(top.code_at(&addr_0), Some(code.to_vec()));
+        assert_eq!(top.code_at(&addr_1), None);
+
+        assert_eq!(top.nonce_of(&addr_0), nonce);
+        assert_eq!(top.nonce_of(&addr_1), zero);
+
+        assert_eq!(top.balance_of(&addr_0), balance_0);
+        assert_eq!(top.balance_of(&addr_1), balance_1);
+
+        assert_eq!(
+            top.read_contract_storage(&addr_0, storage_key_0),
+            Some(storage_value_0)
+        );
+        assert_eq!(
+            top.read_contract_storage(&addr_1, storage_key_1),
+            None
+        );
     }
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,7 +1,7 @@
 use ethabi_contract::use_contract;
-use ethereum_types::U256;
+use ethereum_types::{Address, U256};
 
-use crate::utils;
+use crate::{evm_state::*, utils};
 
 mod cryptozombies;
 mod test_utils;
@@ -160,5 +160,123 @@ fn test_view_call() {
 
         let sub_addr = raw[24..64].to_string();
         assert_eq!(contract.get_code(sub_addr), "");
+    })
+}
+
+#[test]
+fn state_management() {
+    test_utils::run_test(0, |contract| {
+        let addr_0 = Address::repeat_byte(0);
+        let addr_1 = Address::repeat_byte(1);
+        let addr_2 = Address::repeat_byte(2);
+
+        let zero = U256::zero();
+        let code: [u8; 3] = [0, 1, 2];
+        let nonce = U256::from_dec_str("103030303").unwrap();
+        let balance = U256::from_dec_str("3838209").unwrap();
+        let storage_key_0 = [4u8; 32];
+        let storage_key_1 = [5u8; 32];
+        let storage_value_0 = [6u8; 32];
+        let storage_value_1 = [7u8; 32];
+
+        contract.set_code(&addr_0, &code);
+        assert_eq!(contract.code_at(&addr_0), Some(code.to_vec()));
+        assert_eq!(contract.code_at(&addr_1), None);
+        assert_eq!(contract.code_at(&addr_2), None);
+
+        contract.set_nonce(&addr_0, nonce);
+        assert_eq!(contract.nonce_of(&addr_0), nonce);
+        assert_eq!(contract.nonce_of(&addr_1), zero);
+        assert_eq!(contract.nonce_of(&addr_2), zero);
+
+        contract.set_balance(&addr_0, balance);
+        assert_eq!(contract.balance_of(&addr_0), balance);
+        assert_eq!(contract.balance_of(&addr_1), zero);
+        assert_eq!(contract.balance_of(&addr_2), zero);
+
+        contract.set_contract_storage(&addr_0, storage_key_0, storage_value_0);
+        // assert_eq!(contract.read_contract_storage(&addr_0, storage_key_0), Some(storage_value_0));
+        assert_eq!(contract.read_contract_storage(&addr_1, storage_key_0), None);
+        assert_eq!(contract.read_contract_storage(&addr_2, storage_key_0), None);
+
+        let next = {
+            // Open a new store
+            let mut next = StateStore::default();
+            let mut sub1 = SubState::new(&addr_0, &mut next, contract);
+
+            sub1.set_code(&addr_1, &code);
+            assert_eq!(sub1.code_at(&addr_0), Some(code.to_vec()));
+            assert_eq!(sub1.code_at(&addr_1), Some(code.to_vec()));
+            assert_eq!(sub1.code_at(&addr_2), None);
+
+            sub1.set_nonce(&addr_1, nonce);
+            assert_eq!(sub1.nonce_of(&addr_0), nonce);
+            assert_eq!(sub1.nonce_of(&addr_1), nonce);
+            assert_eq!(sub1.nonce_of(&addr_2), zero);
+
+            sub1.set_balance(&addr_1, balance);
+            assert_eq!(sub1.balance_of(&addr_0), balance);
+            assert_eq!(sub1.balance_of(&addr_1), balance);
+            assert_eq!(sub1.balance_of(&addr_2), zero);
+
+            sub1.set_contract_storage(&addr_1, storage_key_0, storage_value_0);
+            // assert_eq!(sub1.read_contract_storage(&addr_0, storage_key_0), Some(storage_value_0));
+            assert_eq!(
+                sub1.read_contract_storage(&addr_1, storage_key_0),
+                Some(storage_value_0)
+            );
+            assert_eq!(sub1.read_contract_storage(&addr_2, storage_key_0), None);
+
+            sub1.set_contract_storage(&addr_1, storage_key_0, storage_value_1);
+            // assert_eq!(sub1.read_contract_storage(&addr_0, storage_key_0), Some(storage_value_0));
+            assert_eq!(
+                sub1.read_contract_storage(&addr_1, storage_key_0),
+                Some(storage_value_1)
+            );
+            assert_eq!(sub1.read_contract_storage(&addr_2, storage_key_0), None);
+
+            sub1.set_contract_storage(&addr_1, storage_key_1, storage_value_1);
+            assert_eq!(
+                sub1.read_contract_storage(&addr_1, storage_key_0),
+                Some(storage_value_1)
+            );
+            assert_eq!(
+                sub1.read_contract_storage(&addr_1, storage_key_1),
+                Some(storage_value_1)
+            );
+
+            sub1.set_contract_storage(&addr_1, storage_key_0, storage_value_0);
+            assert_eq!(
+                sub1.read_contract_storage(&addr_1, storage_key_0),
+                Some(storage_value_0)
+            );
+            assert_eq!(
+                sub1.read_contract_storage(&addr_1, storage_key_1),
+                Some(storage_value_1)
+            );
+
+            next
+        };
+
+        contract.commit_changes(&next);
+        assert_eq!(contract.code_at(&addr_0), Some(code.to_vec()));
+        assert_eq!(contract.code_at(&addr_1), Some(code.to_vec()));
+        assert_eq!(contract.code_at(&addr_2), None);
+        assert_eq!(contract.nonce_of(&addr_0), nonce);
+        assert_eq!(contract.nonce_of(&addr_1), nonce);
+        assert_eq!(contract.nonce_of(&addr_2), zero);
+        assert_eq!(contract.balance_of(&addr_0), balance);
+        assert_eq!(contract.balance_of(&addr_1), balance);
+        assert_eq!(contract.balance_of(&addr_2), zero);
+        // assert_eq!(contract.read_contract_storage(&addr_0, storage_key_0), Some(storage_value_0));
+        assert_eq!(
+            contract.read_contract_storage(&addr_1, storage_key_0),
+            Some(storage_value_0)
+        );
+        assert_eq!(
+            contract.read_contract_storage(&addr_1, storage_key_1),
+            Some(storage_value_1)
+        );
+        assert_eq!(contract.read_contract_storage(&addr_2, storage_key_0), None);
     })
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,19 +4,19 @@ use near_sdk::env;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use vm::CreateContractAddress;
 
+pub fn internal_storage_key(address: &Address, key: [u8; 32]) -> [u8; 52] {
+    let mut k = [0u8; 52];
+    k[..20].copy_from_slice(address.as_ref());
+    k[20..].copy_from_slice(&key);
+    k
+}
+
 pub fn predecessor_as_evm() -> Address {
     near_account_id_to_evm_address(&env::predecessor_account_id())
 }
 
 pub fn predecessor_as_internal_address() -> [u8; 20] {
     near_account_id_to_internal_address(&env::predecessor_account_id())
-}
-
-pub fn prefix_for_contract_storage(contract_address: &[u8]) -> Vec<u8> {
-    let mut prefix = Vec::new();
-    prefix.extend_from_slice(b"_storage");
-    prefix.extend_from_slice(contract_address);
-    prefix
 }
 
 pub fn evm_account_to_internal_address(addr: Address) -> [u8; 20] {
@@ -99,7 +99,7 @@ pub fn evm_contract_address(
     }
 }
 
-#[derive(Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Eq, PartialEq, Debug, Ord, PartialOrd)]
 pub struct Balance(pub u128);
 
 impl Balance {


### PR DESCRIPTION
Contract storage is now keyed by `address | key`, rather than as a nested map.

TODO:
- [x] handle self-destructs in substates
  - [x] Mark contract destructed
  - [x] prevent code/nonce/balance/storage from being read
  - [x] if recreated, clear nonce, balance, code
  - [x] if recreated, clear storage via iteration over keys
  - [x] commit upwards
- [x] handle self-destructs in the EVM state
  - [x] clear nonce & balance & code
  - [x] iterate to clear storage
  - [x] ensure that if a contract was self destructed and recreated, its state gets cleared