### PR TITLE
feature: ECDSA contract first take

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ near create_account evm --masterAccount=<account you used in near login/test.nea
 near deploy --accountId=evm --wasmFile=res/near_evm.wasm
 ```
 
-* TODO: hackery to actually deploy your EVM contract
-
 ### Testing
 
 1. Build the evm contract

--- a/contracts/ECDSA.sol
+++ b/contracts/ECDSA.sol
@@ -24,6 +24,7 @@ contract NearECDSA {
     }
 
     function recover(bytes32 _hash, bytes memory signature) external view returns (address) {
+        address signer = recoverRaw(_hash, signature);
         address _account = accounts[signer];
         return _account == address(0) ? signer : _account;
     }

--- a/contracts/ECDSA.sol
+++ b/contracts/ECDSA.sol
@@ -29,7 +29,7 @@ contract NearECDSA {
         return _account == address(0) ? signer : _account;
     }
 
-    function recoverRaw(bytes32 hash, bytes memory signature) private pure returns (address) {
+    function recoverRaw(bytes32 hash, bytes memory signature) public pure returns (address) {
         return ECDSA.recover(hash, signature);
     }
 

--- a/contracts/ECDSA.sol
+++ b/contracts/ECDSA.sol
@@ -15,7 +15,15 @@ contract NearECDSA {
 
     mapping (address => address) public accounts;
 
-    function registerSigner(address signer) external {
+    function registerSigner(address signer, bytes memory signature) external {
+        // We require that they prove key ownership
+        // The digest that ought to be signed is
+        // keccak256("NearECDSA" | 20-byte truncated public key hash | 20-byte near evm account)
+        bytes32 digest = keccak256(abi.encodePacked("NearECDSA"), signer, msg.sender);
+        require(
+            signer == recoverRaw(digest, signature),
+            "NearECDSA/registerSigner -- Delegated key must sign near account."
+        );
         accounts[signer] = msg.sender;
     }
 

--- a/contracts/ECDSA.sol
+++ b/contracts/ECDSA.sol
@@ -1,0 +1,146 @@
+pragma solidity ^0.6.0;
+
+
+/**
+ * @dev Elliptic Curve Digital Signature Algorithm (ECDSA) operations.
+ *
+ * These functions can be used to verify that a message was signed by the holder
+ * of ECDSA keys corresponding to a certain account.
+ *
+ * Accounts may register
+ */
+contract NearECDSA {
+
+    constructor () public {}
+
+    mapping (address => address) public accounts;
+
+    function registerSigner(address signer) external {
+        accounts[signer] = msg.sender;
+    }
+
+    function unregisterSigner(address signer) external {
+        if (accounts[signer] = msg.sender) accounts[signer] = address(0);
+    }
+
+    function recover(bytes32 _hash, bytes memory signature) external view returns (address) {
+        address _account = accounts[signer];
+        return _account == address(0) ? signer : _account;
+    }
+
+    function recoverRaw(bytes32 hash, bytes memory signature) private pure returns (address) {
+        return ECDSA.recover(hash, signature);
+    }
+
+    function toEthSignedMessageHash(bytes32 hash) internal pure returns (bytes32) {
+        return ECDSA.toEthSignedMessageHash(hash);
+    }
+}
+
+/**
+ * @dev Elliptic Curve Digital Signature Algorithm (ECDSA) operations.
+ *
+ * These functions can be used to verify that a message was signed by the holder
+ * of the private keys of a given address.
+ */
+library ECDSA {
+    /**
+     * @dev Returns the address that signed a hashed message (`hash`) with
+     * `signature`. This address can then be used for verification purposes.
+     *
+     * The `ecrecover` EVM opcode allows for malleable (non-unique) signatures:
+     * this function rejects them by requiring the `s` value to be in the lower
+     * half order, and the `v` value to be either 27 or 28.
+     *
+     * IMPORTANT: `hash` _must_ be the result of a hash operation for the
+     * verification to be secure: it is possible to craft signatures that
+     * recover to arbitrary addresses for non-hashed data. A safe way to ensure
+     * this is by receiving a hash of the original message (which may otherwise
+     * be too long), and then calling {toEthSignedMessageHash} on it.
+     */
+    function recover(bytes32 hash, bytes memory signature) internal pure returns (address) {
+        // Check the signature length
+        if (signature.length != 65) {
+            revert("ECDSA: invalid signature length");
+        }
+
+        // Divide the signature in r, s and v variables
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+
+        // ecrecover takes the signature parameters, and the only way to get them
+        // currently is to use assembly.
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            r := mload(add(signature, 0x20))
+            s := mload(add(signature, 0x40))
+            v := byte(0, mload(add(signature, 0x60)))
+        }
+
+        // EIP-2 still allows signature malleability for ecrecover(). Remove this possibility and make the signature
+        // unique. Appendix F in the Ethereum Yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf), defines
+        // the valid range for s in (281): 0 < s < secp256k1n ÷ 2 + 1, and for v in (282): v ∈ {27, 28}. Most
+        // signatures from current libraries generate a unique signature with an s-value in the lower half order.
+        //
+        // If your library generates malleable signatures, such as s-values in the upper range, calculate a new s-value
+        // with 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - s1 and flip v from 27 to 28 or
+        // vice versa. If your library also generates signatures with 0/1 for v instead 27/28, add 27 to v to accept
+        // these malleable signatures as well.
+        if (uint256(s) > 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0) {
+            revert("ECDSA: invalid signature 's' value");
+        }
+
+        if (v != 27 && v != 28) {
+            revert("ECDSA: invalid signature 'v' value");
+        }
+
+        // If the signature is valid (and not malleable), return the signer address
+        address signer = ecrecover(hash, v, r, s);
+        require(signer != address(0), "ECDSA: invalid signature");
+
+        return signer;
+    }
+
+    /**
+     * @dev Returns an Ethereum Signed Message, created from a `hash`. This
+     * replicates the behavior of the
+     * https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_sign[`eth_sign`]
+     * JSON-RPC method.
+     *
+     * See {recover}.
+     */
+    function toEthSignedMessageHash(bytes32 hash) internal pure returns (bytes32) {
+        // 32 is the length in bytes of hash,
+        // enforced by the type signature above
+        return keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash));
+    }
+}
+
+
+/*
+https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/cryptography/ECDSA.sol
+
+The MIT License (MIT)
+
+Copyright (c) 2016-2020 zOS Global Limited
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::too_many_arguments)]
+
 use std::sync::Arc;
 
 use ethereum_types::{Address, U256};
@@ -98,6 +100,7 @@ pub fn _create<T: EvmState>(
 
     (result.ok().unwrap().ok(), Some(store))
 }
+
 
 pub fn call<T: EvmState>(
     state: &mut T,


### PR DESCRIPTION
Adds an ECDSA key registry in the EVM for good ergonomics using `ecrecover`. It conforms (as closely as possible) with the OZ interface, and allows near accounts to register EVM addresses whose keys may sign messages on their behalf