### PR TITLE
replace test_utils::run_test() with initialize()

### DIFF
--- a/src/tests/cryptozombies.rs
+++ b/src/tests/cryptozombies.rs
@@ -28,35 +28,34 @@ fn get_zombies_by_owner(contract: &mut EvmContract, addr: &String, owner: Addres
 #[test]
 // CryptoZombies
 fn test_create_random_zombie() {
-    test_utils::run_test(0, |mut contract| {
-        let addr = deploy_cryptozombies(&mut contract);
-        assert_eq!(
-            get_zombies_by_owner(
-                &mut contract,
-                &addr,
-                utils::near_account_id_to_evm_address(&"owner1".to_string())
-            ),
-            []
-        );
+    let mut contract = test_utils::initialize();
+    let addr = deploy_cryptozombies(&mut contract);
+    assert_eq!(
+        get_zombies_by_owner(
+            &mut contract,
+            &addr,
+            utils::near_account_id_to_evm_address(&"owner1".to_string())
+        ),
+        []
+    );
 
-        create_random_zombie(&mut contract, &addr, "zomb1");
-        assert_eq!(
-            get_zombies_by_owner(
-                &mut contract,
-                &addr,
-                utils::near_account_id_to_evm_address(&"owner1".to_string())
-            ),
-            [Uint::from(0)]
-        );
+    create_random_zombie(&mut contract, &addr, "zomb1");
+    assert_eq!(
+        get_zombies_by_owner(
+            &mut contract,
+            &addr,
+            utils::near_account_id_to_evm_address(&"owner1".to_string())
+        ),
+        [Uint::from(0)]
+    );
 
-        create_random_zombie(&mut contract, &addr, "zomb2");
-        assert_eq!(
-            get_zombies_by_owner(
-                &mut contract,
-                &addr,
-                utils::near_account_id_to_evm_address(&"owner1".to_string())
-            ),
-            [Uint::from(0)]
-        );
-    });
+    create_random_zombie(&mut contract, &addr, "zomb2");
+    assert_eq!(
+        get_zombies_by_owner(
+            &mut contract,
+            &addr,
+            utils::near_account_id_to_evm_address(&"owner1".to_string())
+        ),
+        [Uint::from(0)]
+    );
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -17,333 +17,330 @@ lazy_static_include_str!(CONSTRUCTOR_TEST, "src/tests/build/ConstructorRevert.bi
 
 #[test]
 fn test_sends() {
-    test_utils::run_test(100, |contract| {
-        let evm_acc = hex::encode(utils::near_account_id_to_evm_address("evmGuy").0);
+    let mut contract = test_utils::initialize();
+    let evm_acc = hex::encode(utils::near_account_id_to_evm_address("evmGuy").0);
 
-        assert_eq!(contract.balance_of_near_account("owner1".to_string()).0, 0);
-        contract.add_near();
-        assert_eq!(
-            contract.balance_of_near_account("owner1".to_string()).0,
-            100
-        );
+    assert_eq!(contract.balance_of_near_account("owner1".to_string()).0, 0);
+    test_utils::attach_deposit(100);
+    contract.add_near();
+    assert_eq!(
+        contract.balance_of_near_account("owner1".to_string()).0,
+        100
+    );
 
-        contract.move_funds_to_evm_address(evm_acc.clone(), utils::Balance(50));
-        assert_eq!(contract.balance_of_near_account("owner1".to_string()).0, 50);
-        assert_eq!(contract.balance_of_evm_address(evm_acc).0, 50);
+    contract.move_funds_to_evm_address(evm_acc.clone(), utils::Balance(50));
+    assert_eq!(contract.balance_of_near_account("owner1".to_string()).0, 50);
+    assert_eq!(contract.balance_of_evm_address(evm_acc).0, 50);
 
-        contract.move_funds_to_near_account("someGuy".to_string(), utils::Balance(25));
-        assert_eq!(contract.balance_of_near_account("owner1".to_string()).0, 25);
-        assert_eq!(
-            contract.balance_of_near_account("someGuy".to_string()).0,
-            25
-        );
-        // TODO: assert contract NEAR balance
-    })
+    contract.move_funds_to_near_account("someGuy".to_string(), utils::Balance(25));
+    assert_eq!(contract.balance_of_near_account("owner1".to_string()).0, 25);
+    assert_eq!(
+        contract.balance_of_near_account("someGuy".to_string()).0,
+        25
+    );
+    // TODO: assert contract NEAR balance
 }
 
 #[test]
 fn test_deploy_with_nonce() {
-    test_utils::run_test(0, |contract| {
-        let evm_acc = hex::encode(utils::near_account_id_to_evm_address("owner1").0);
-        assert_eq!(contract.nonce_of_near_account("owner1".to_string()).0, 0);
-        assert_eq!(contract.nonce_of_evm_address(evm_acc.clone()).0, 0);
+    let mut contract = test_utils::initialize();
+    let evm_acc = hex::encode(utils::near_account_id_to_evm_address("owner1").0);
+    assert_eq!(contract.nonce_of_near_account("owner1".to_string()).0, 0);
+    assert_eq!(contract.nonce_of_evm_address(evm_acc.clone()).0, 0);
 
-        contract.deploy_code(TEST.to_string());
-        assert_eq!(contract.nonce_of_near_account("owner1".to_string()).0, 1);
-        assert_eq!(contract.nonce_of_evm_address(evm_acc.clone()).0, 1);
+    contract.deploy_code(TEST.to_string());
+    assert_eq!(contract.nonce_of_near_account("owner1".to_string()).0, 1);
+    assert_eq!(contract.nonce_of_evm_address(evm_acc.clone()).0, 1);
 
-        contract.deploy_code(TEST.to_string()); // at a different address
-        assert_eq!(contract.nonce_of_near_account("owner1".to_string()).0, 2);
-        assert_eq!(contract.nonce_of_evm_address(evm_acc.clone()).0, 2);
-    })
+    contract.deploy_code(TEST.to_string()); // at a different address
+    assert_eq!(contract.nonce_of_near_account("owner1".to_string()).0, 2);
+    assert_eq!(contract.nonce_of_evm_address(evm_acc.clone()).0, 2);
 }
 
 #[test]
 #[should_panic]
 fn test_failed_deploy_returns_error() {
-    test_utils::run_test(0, |contract| {
-        contract.deploy_code(CONSTRUCTOR_TEST.to_string());
-    })
+    let mut contract = test_utils::initialize();
+    contract.deploy_code(CONSTRUCTOR_TEST.to_string());
+
 }
 
 #[test]
 fn test_internal_create() {
-    test_utils::run_test(0, |contract| {
-        let test_addr = contract.deploy_code(TEST.to_string());
-        assert_eq!(contract.nonce_of_evm_address(test_addr.clone()).0, 0);
+    let mut contract = test_utils::initialize();
+    let test_addr = contract.deploy_code(TEST.to_string());
+    assert_eq!(contract.nonce_of_evm_address(test_addr.clone()).0, 0);
 
-        // This should increment the nonce of the deploying contract
-        let (input, _) = soltest::functions::deploy_new_guy::call(8);
-        let raw = contract.call_contract(test_addr.clone(), hex::encode(input));
-        assert_eq!(contract.nonce_of_evm_address(test_addr.clone()).0, 1);
+    // This should increment the nonce of the deploying contract
+    let (input, _) = soltest::functions::deploy_new_guy::call(8);
+    let raw = contract.call_contract(test_addr.clone(), hex::encode(input));
+    assert_eq!(contract.nonce_of_evm_address(test_addr.clone()).0, 1);
 
-        let sub_addr = raw[24..64].to_string();
-        let (new_input, _) = subcontract::functions::a_number::call();
-        let new_raw = contract.call_contract(sub_addr, hex::encode(new_input));
-        let output =
-            subcontract::functions::a_number::decode_output(&hex::decode(&new_raw).unwrap())
-                .unwrap();
-        assert_eq!(output, U256::from(8));
-    })
+    let sub_addr = raw[24..64].to_string();
+    let (new_input, _) = subcontract::functions::a_number::call();
+    let new_raw = contract.call_contract(sub_addr, hex::encode(new_input));
+    let output =
+        subcontract::functions::a_number::decode_output(&hex::decode(&new_raw).unwrap())
+            .unwrap();
+    assert_eq!(output, U256::from(8));
 }
 
 #[test]
 fn test_deploy_and_transfer() {
-    test_utils::run_test(100, |contract| {
-        let test_addr = contract.deploy_code(TEST.to_string());
-        assert_eq!(contract.balance_of_evm_address(test_addr.clone()).0, 100);
+    let mut contract = test_utils::initialize();
+    test_utils::attach_deposit(100);
+    let test_addr = contract.deploy_code(TEST.to_string());
+    assert_eq!(contract.balance_of_evm_address(test_addr.clone()).0, 100);
 
-        // This should increment the nonce of the deploying contract
-        // There is 100 attached to this that should be passed through
-        let (input, _) = soltest::functions::deploy_new_guy::call(8);
-        let raw = contract.call_contract(test_addr.clone(), hex::encode(input));
+    // This should increment the nonce of the deploying contract
+    // There is 100 attached to this that should be passed through
+    let (input, _) = soltest::functions::deploy_new_guy::call(8);
+    let raw = contract.call_contract(test_addr.clone(), hex::encode(input));
 
-        // The sub_addr should have been transferred 100 monies
-        let sub_addr = raw[24..64].to_string();
-        assert_eq!(contract.balance_of_evm_address(test_addr).0, 100);
-        assert_eq!(contract.balance_of_evm_address(sub_addr).0, 100);
-    })
+    // The sub_addr should have been transferred 100 monies
+    let sub_addr = raw[24..64].to_string();
+    assert_eq!(contract.balance_of_evm_address(test_addr).0, 100);
+    assert_eq!(contract.balance_of_evm_address(sub_addr).0, 100);
 }
 
 #[test]
 fn test_deploy_with_value() {
-    test_utils::run_test(100, |contract| {
-        // This test is identical to the previous one
-        // As we expect behavior to be the same.
-        let test_addr = contract.deploy_code(TEST.to_string());
-        assert_eq!(contract.balance_of_evm_address(test_addr.clone()).0, 100);
+    let mut contract = test_utils::initialize();
+    test_utils::attach_deposit(100);
 
-        // This should increment the nonce of the deploying contract
-        // There is 100 attached to this that should be passed through
-        let (input, _) = soltest::functions::pay_new_guy::call(8);
-        let raw = contract.call_contract(test_addr.clone(), hex::encode(input));
+    // This test is identical to the previous one
+    // As we expect behavior to be the same.
+    let test_addr = contract.deploy_code(TEST.to_string());
+    assert_eq!(contract.balance_of_evm_address(test_addr.clone()).0, 100);
 
-        // The sub_addr should have been transferred 100 monies
-        let sub_addr = raw[24..64].to_string();
-        assert_eq!(contract.balance_of_evm_address(test_addr).0, 100);
-        assert_eq!(contract.balance_of_evm_address(sub_addr).0, 100);
-    })
+    // This should increment the nonce of the deploying contract
+    // There is 100 attached to this that should be passed through
+    let (input, _) = soltest::functions::pay_new_guy::call(8);
+    let raw = contract.call_contract(test_addr.clone(), hex::encode(input));
+
+    // The sub_addr should have been transferred 100 monies
+    let sub_addr = raw[24..64].to_string();
+    assert_eq!(contract.balance_of_evm_address(test_addr).0, 100);
+    assert_eq!(contract.balance_of_evm_address(sub_addr).0, 100);
 }
 
 #[test]
 fn test_contract_to_eoa_transfer() {
-    test_utils::run_test(100, |contract| {
-        // This test is identical to the previous one
-        // As we expect behavior to be the same.
-        let test_addr = contract.deploy_code(TEST.to_string());
-        assert_eq!(contract.balance_of_evm_address(test_addr.clone()).0, 100);
+    let mut contract = test_utils::initialize();
+    test_utils::attach_deposit(100);
 
-        let (input, _) = soltest::functions::return_some_funds::call();
-        let raw = contract.call_contract(test_addr.clone(), hex::encode(input));
+    // This test is identical to the previous one
+    // As we expect behavior to be the same.
+    let test_addr = contract.deploy_code(TEST.to_string());
+    assert_eq!(contract.balance_of_evm_address(test_addr.clone()).0, 100);
 
-        let sender_addr = raw[24..64].to_string();
-        assert_eq!(contract.balance_of_evm_address(test_addr).0, 150);
-        assert_eq!(contract.balance_of_evm_address(sender_addr).0, 50);
-    })
+    let (input, _) = soltest::functions::return_some_funds::call();
+    let raw = contract.call_contract(test_addr.clone(), hex::encode(input));
+
+    let sender_addr = raw[24..64].to_string();
+    assert_eq!(contract.balance_of_evm_address(test_addr).0, 150);
+    assert_eq!(contract.balance_of_evm_address(sender_addr).0, 50);
 }
 
 #[test]
 fn test_get_code() {
-    test_utils::run_test(0, |contract| {
-        let test_addr = contract.deploy_code(TEST.to_string());
-        assert!(contract.get_code(test_addr).len() > 3000); // contract code should roughly be over length 3000
+    let mut contract = test_utils::initialize();
+    let test_addr = contract.deploy_code(TEST.to_string());
+    assert!(contract.get_code(test_addr).len() > 3000); // contract code should roughly be over length 3000
 
-        let no_code_addr = "0000000000000000000000000000000000000000".to_owned();
-        assert_eq!(contract.get_code(no_code_addr), "");
-    })
+    let no_code_addr = "0000000000000000000000000000000000000000".to_owned();
+    assert_eq!(contract.get_code(no_code_addr), "");
 }
 
 #[test]
 fn test_view_call() {
-    test_utils::run_test(0, |contract| {
-        let test_addr = contract.deploy_code(TEST.to_string());
+    let mut contract = test_utils::initialize();
+    let test_addr = contract.deploy_code(TEST.to_string());
 
-        // This should NOT increment the nonce of the deploying contract
-        // And NO CODE should be deployed
-        let (input, _) = soltest::functions::deploy_new_guy::call(8);
-        let raw = contract.view_call_contract(
-            test_addr.clone(),
-            hex::encode(input),
-            test_addr.clone(),
-            utils::Balance(0),
-        );
-        assert_eq!(contract.nonce_of_evm_address(test_addr.clone()).0, 0);
+    // This should NOT increment the nonce of the deploying contract
+    // And NO CODE should be deployed
+    let (input, _) = soltest::functions::deploy_new_guy::call(8);
+    let raw = contract.view_call_contract(
+        test_addr.clone(),
+        hex::encode(input),
+        test_addr.clone(),
+        utils::Balance(0),
+    );
+    assert_eq!(contract.nonce_of_evm_address(test_addr.clone()).0, 0);
 
-        let sub_addr = raw[24..64].to_string();
-        assert_eq!(contract.get_code(sub_addr), "");
-    })
+    let sub_addr = raw[24..64].to_string();
+    assert_eq!(contract.get_code(sub_addr), "");
 }
 
 #[test]
 fn test_accurate_storage_on_selfdestruct() {
-    test_utils::run_test(100, |contract|  {
-        contract.add_near();
-        test_utils::reset_context(); // clear attached deposit
+    let mut contract = test_utils::initialize();
+    test_utils::attach_deposit(100);
+    contract.add_near();
+    test_utils::set_default_context(); // clear attached deposit
 
-        let salt = H256([0u8; 32]);
-        let destruct_code = hex::decode(DESTRUCT_TEST.to_string()).expect("invalid hex");
+    let salt = H256([0u8; 32]);
+    let destruct_code = hex::decode(DESTRUCT_TEST.to_string()).expect("invalid hex");
 
-        // Deploy CREATE2 Factory
-        let factory_addr = contract.deploy_code(FACTORY_TEST.to_string());
+    // Deploy CREATE2 Factory
+    let factory_addr = contract.deploy_code(FACTORY_TEST.to_string());
 
-        // Deploy SelfDestruct contract using CREATE2 and confirm code at address
-        let mut input = create2factory::functions::deploy::call(salt, destruct_code.clone()).0;
-        let mut raw = contract.call_contract(factory_addr.clone(), hex::encode(input));
-        let destruct_addr = raw[24..64].to_string();
-        assert!(contract.get_code(destruct_addr.clone()).len() > 1000);
+    // Deploy SelfDestruct contract using CREATE2 and confirm code at address
+    let mut input = create2factory::functions::deploy::call(salt, destruct_code.clone()).0;
+    let mut raw = contract.call_contract(factory_addr.clone(), hex::encode(input));
+    let destruct_addr = raw[24..64].to_string();
+    assert!(contract.get_code(destruct_addr.clone()).len() > 1000);
 
-        // Write to and successfully read from storage
-        let stored_uint = 5;
-        input = selfdestruct::functions::store_uint::call(stored_uint).0;
-        contract.call_contract(destruct_addr.clone(), hex::encode(input));
-        input = selfdestruct::functions::stored_uint::call().0;
-        raw = contract.call_contract(destruct_addr.clone(), hex::encode(input));
-        assert_eq!(stored_uint, raw.parse::<i32>().unwrap());
+    // Write to and successfully read from storage
+    let stored_uint = 5;
+    input = selfdestruct::functions::store_uint::call(stored_uint).0;
+    contract.call_contract(destruct_addr.clone(), hex::encode(input));
+    input = selfdestruct::functions::stored_uint::call().0;
+    raw = contract.call_contract(destruct_addr.clone(), hex::encode(input));
+    assert_eq!(stored_uint, raw.parse::<i32>().unwrap());
 
-        // Send money to SelfDestruct Contract
-        contract.move_funds_to_evm_address(destruct_addr.clone(), utils::Balance(10));
-        assert_eq!(contract.balance_of_evm_address(destruct_addr.clone()), utils::Balance(10));
+    // Send money to SelfDestruct Contract
+    contract.move_funds_to_evm_address(destruct_addr.clone(), utils::Balance(10));
+    assert_eq!(contract.balance_of_evm_address(destruct_addr.clone()), utils::Balance(10));
 
-        // Destroy contract and confirm 0 balance
-        input = selfdestruct::functions::destruction::call().0;
-        contract.call_contract(destruct_addr.clone(), hex::encode(input));
-        assert_eq!(contract.balance_of_evm_address(destruct_addr.clone()), utils::Balance(0));
-        assert_eq!(contract.get_code(destruct_addr.clone()).len(), 0);
+    // Destroy contract and confirm 0 balance
+    input = selfdestruct::functions::destruction::call().0;
+    contract.call_contract(destruct_addr.clone(), hex::encode(input));
+    assert_eq!(contract.balance_of_evm_address(destruct_addr.clone()), utils::Balance(0));
+    assert_eq!(contract.get_code(destruct_addr.clone()).len(), 0);
 
-        // Send money to SelfDestruct Contract and confirm balance
-        contract.move_funds_to_evm_address(destruct_addr.clone(), utils::Balance(10));
-        assert_eq!(contract.balance_of_evm_address(destruct_addr.clone()), utils::Balance(10));
+    // Send money to SelfDestruct Contract and confirm balance
+    contract.move_funds_to_evm_address(destruct_addr.clone(), utils::Balance(10));
+    assert_eq!(contract.balance_of_evm_address(destruct_addr.clone()), utils::Balance(10));
 
-        // Redeploy contract to same address with CREATE2 and confirm balance
-        input = create2factory::functions::deploy::call(salt, destruct_code.clone()).0;
-        contract.call_contract(factory_addr.clone(), hex::encode(input));
-        assert_eq!(contract.balance_of_evm_address(destruct_addr.clone()), utils::Balance(10));
+    // Redeploy contract to same address with CREATE2 and confirm balance
+    input = create2factory::functions::deploy::call(salt, destruct_code.clone()).0;
+    contract.call_contract(factory_addr.clone(), hex::encode(input));
+    assert_eq!(contract.balance_of_evm_address(destruct_addr.clone()), utils::Balance(10));
 
-        // Confirm empty storage on fresh contract
-        input = selfdestruct::functions::stored_uint::call().0;
-        raw = contract.call_contract(destruct_addr.clone(), hex::encode(input));
-        assert_eq!(0, raw.parse::<i32>().unwrap());
+    // Confirm empty storage on fresh contract
+    input = selfdestruct::functions::stored_uint::call().0;
+    raw = contract.call_contract(destruct_addr.clone(), hex::encode(input));
+    assert_eq!(0, raw.parse::<i32>().unwrap());
 
-        input = selfdestruct::functions::stored_address::call().0;
-        raw = contract.call_contract(destruct_addr.clone(), hex::encode(input));
-        assert_eq!(0, raw.parse::<i32>().unwrap());
-    })
+    input = selfdestruct::functions::stored_address::call().0;
+    raw = contract.call_contract(destruct_addr.clone(), hex::encode(input));
+    assert_eq!(0, raw.parse::<i32>().unwrap());
 }
 
 #[test]
 fn state_management() {
-    test_utils::run_test(0, |contract| {
-        let addr_0 = Address::repeat_byte(0);
-        let addr_1 = Address::repeat_byte(1);
-        let addr_2 = Address::repeat_byte(2);
+    let mut contract = test_utils::initialize();
+    let addr_0 = Address::repeat_byte(0);
+    let addr_1 = Address::repeat_byte(1);
+    let addr_2 = Address::repeat_byte(2);
 
-        let zero = U256::zero();
-        let code: [u8; 3] = [0, 1, 2];
-        let nonce = U256::from_dec_str("103030303").unwrap();
-        let balance = U256::from_dec_str("3838209").unwrap();
-        let storage_key_0 = [4u8; 32];
-        let storage_key_1 = [5u8; 32];
-        let storage_value_0 = [6u8; 32];
-        let storage_value_1 = [7u8; 32];
+    let zero = U256::zero();
+    let code: [u8; 3] = [0, 1, 2];
+    let nonce = U256::from_dec_str("103030303").unwrap();
+    let balance = U256::from_dec_str("3838209").unwrap();
+    let storage_key_0 = [4u8; 32];
+    let storage_key_1 = [5u8; 32];
+    let storage_value_0 = [6u8; 32];
+    let storage_value_1 = [7u8; 32];
 
-        contract.set_code(&addr_0, &code);
-        assert_eq!(contract.code_at(&addr_0), Some(code.to_vec()));
-        assert_eq!(contract.code_at(&addr_1), None);
-        assert_eq!(contract.code_at(&addr_2), None);
+    contract.set_code(&addr_0, &code);
+    assert_eq!(contract.code_at(&addr_0), Some(code.to_vec()));
+    assert_eq!(contract.code_at(&addr_1), None);
+    assert_eq!(contract.code_at(&addr_2), None);
 
-        contract.set_nonce(&addr_0, nonce);
-        assert_eq!(contract.nonce_of(&addr_0), nonce);
-        assert_eq!(contract.nonce_of(&addr_1), zero);
-        assert_eq!(contract.nonce_of(&addr_2), zero);
+    contract.set_nonce(&addr_0, nonce);
+    assert_eq!(contract.nonce_of(&addr_0), nonce);
+    assert_eq!(contract.nonce_of(&addr_1), zero);
+    assert_eq!(contract.nonce_of(&addr_2), zero);
 
-        contract.set_balance(&addr_0, balance);
-        assert_eq!(contract.balance_of(&addr_0), balance);
-        assert_eq!(contract.balance_of(&addr_1), zero);
-        assert_eq!(contract.balance_of(&addr_2), zero);
+    contract.set_balance(&addr_0, balance);
+    assert_eq!(contract.balance_of(&addr_0), balance);
+    assert_eq!(contract.balance_of(&addr_1), zero);
+    assert_eq!(contract.balance_of(&addr_2), zero);
 
-        contract.set_contract_storage(&addr_0, storage_key_0, storage_value_0);
-        // assert_eq!(contract.read_contract_storage(&addr_0, storage_key_0), Some(storage_value_0));
-        assert_eq!(contract.read_contract_storage(&addr_1, storage_key_0), None);
-        assert_eq!(contract.read_contract_storage(&addr_2, storage_key_0), None);
+    contract.set_contract_storage(&addr_0, storage_key_0, storage_value_0);
+    // assert_eq!(contract.read_contract_storage(&addr_0, storage_key_0), Some(storage_value_0));
+    assert_eq!(contract.read_contract_storage(&addr_1, storage_key_0), None);
+    assert_eq!(contract.read_contract_storage(&addr_2, storage_key_0), None);
 
-        let next = {
-            // Open a new store
-            let mut next = StateStore::default();
-            let mut sub1 = SubState::new(&addr_0, &mut next, contract);
+    let next = {
+        // Open a new store
+        let mut next = StateStore::default();
+        let mut sub1 = SubState::new(&addr_0, &mut next, &contract);
 
-            sub1.set_code(&addr_1, &code);
-            assert_eq!(sub1.code_at(&addr_0), Some(code.to_vec()));
-            assert_eq!(sub1.code_at(&addr_1), Some(code.to_vec()));
-            assert_eq!(sub1.code_at(&addr_2), None);
+        sub1.set_code(&addr_1, &code);
+        assert_eq!(sub1.code_at(&addr_0), Some(code.to_vec()));
+        assert_eq!(sub1.code_at(&addr_1), Some(code.to_vec()));
+        assert_eq!(sub1.code_at(&addr_2), None);
 
-            sub1.set_nonce(&addr_1, nonce);
-            assert_eq!(sub1.nonce_of(&addr_0), nonce);
-            assert_eq!(sub1.nonce_of(&addr_1), nonce);
-            assert_eq!(sub1.nonce_of(&addr_2), zero);
+        sub1.set_nonce(&addr_1, nonce);
+        assert_eq!(sub1.nonce_of(&addr_0), nonce);
+        assert_eq!(sub1.nonce_of(&addr_1), nonce);
+        assert_eq!(sub1.nonce_of(&addr_2), zero);
 
-            sub1.set_balance(&addr_1, balance);
-            assert_eq!(sub1.balance_of(&addr_0), balance);
-            assert_eq!(sub1.balance_of(&addr_1), balance);
-            assert_eq!(sub1.balance_of(&addr_2), zero);
+        sub1.set_balance(&addr_1, balance);
+        assert_eq!(sub1.balance_of(&addr_0), balance);
+        assert_eq!(sub1.balance_of(&addr_1), balance);
+        assert_eq!(sub1.balance_of(&addr_2), zero);
 
-            sub1.set_contract_storage(&addr_1, storage_key_0, storage_value_0);
-            // assert_eq!(sub1.read_contract_storage(&addr_0, storage_key_0), Some(storage_value_0));
-            assert_eq!(
-                sub1.read_contract_storage(&addr_1, storage_key_0),
-                Some(storage_value_0)
-            );
-            assert_eq!(sub1.read_contract_storage(&addr_2, storage_key_0), None);
-
-            sub1.set_contract_storage(&addr_1, storage_key_0, storage_value_1);
-            // assert_eq!(sub1.read_contract_storage(&addr_0, storage_key_0), Some(storage_value_0));
-            assert_eq!(
-                sub1.read_contract_storage(&addr_1, storage_key_0),
-                Some(storage_value_1)
-            );
-            assert_eq!(sub1.read_contract_storage(&addr_2, storage_key_0), None);
-
-            sub1.set_contract_storage(&addr_1, storage_key_1, storage_value_1);
-            assert_eq!(
-                sub1.read_contract_storage(&addr_1, storage_key_0),
-                Some(storage_value_1)
-            );
-            assert_eq!(
-                sub1.read_contract_storage(&addr_1, storage_key_1),
-                Some(storage_value_1)
-            );
-
-            sub1.set_contract_storage(&addr_1, storage_key_0, storage_value_0);
-            assert_eq!(
-                sub1.read_contract_storage(&addr_1, storage_key_0),
-                Some(storage_value_0)
-            );
-            assert_eq!(
-                sub1.read_contract_storage(&addr_1, storage_key_1),
-                Some(storage_value_1)
-            );
-
-            next
-        };
-
-        contract.commit_changes(&next);
-        assert_eq!(contract.code_at(&addr_0), Some(code.to_vec()));
-        assert_eq!(contract.code_at(&addr_1), Some(code.to_vec()));
-        assert_eq!(contract.code_at(&addr_2), None);
-        assert_eq!(contract.nonce_of(&addr_0), nonce);
-        assert_eq!(contract.nonce_of(&addr_1), nonce);
-        assert_eq!(contract.nonce_of(&addr_2), zero);
-        assert_eq!(contract.balance_of(&addr_0), balance);
-        assert_eq!(contract.balance_of(&addr_1), balance);
-        assert_eq!(contract.balance_of(&addr_2), zero);
-        // assert_eq!(contract.read_contract_storage(&addr_0, storage_key_0), Some(storage_value_0));
+        sub1.set_contract_storage(&addr_1, storage_key_0, storage_value_0);
+        // assert_eq!(sub1.read_contract_storage(&addr_0, storage_key_0), Some(storage_value_0));
         assert_eq!(
-            contract.read_contract_storage(&addr_1, storage_key_0),
+            sub1.read_contract_storage(&addr_1, storage_key_0),
+            Some(storage_value_0)
+        );
+        assert_eq!(sub1.read_contract_storage(&addr_2, storage_key_0), None);
+
+        sub1.set_contract_storage(&addr_1, storage_key_0, storage_value_1);
+        // assert_eq!(sub1.read_contract_storage(&addr_0, storage_key_0), Some(storage_value_0));
+        assert_eq!(
+            sub1.read_contract_storage(&addr_1, storage_key_0),
+            Some(storage_value_1)
+        );
+        assert_eq!(sub1.read_contract_storage(&addr_2, storage_key_0), None);
+
+        sub1.set_contract_storage(&addr_1, storage_key_1, storage_value_1);
+        assert_eq!(
+            sub1.read_contract_storage(&addr_1, storage_key_0),
+            Some(storage_value_1)
+        );
+        assert_eq!(
+            sub1.read_contract_storage(&addr_1, storage_key_1),
+            Some(storage_value_1)
+        );
+
+        sub1.set_contract_storage(&addr_1, storage_key_0, storage_value_0);
+        assert_eq!(
+            sub1.read_contract_storage(&addr_1, storage_key_0),
             Some(storage_value_0)
         );
         assert_eq!(
-            contract.read_contract_storage(&addr_1, storage_key_1),
+            sub1.read_contract_storage(&addr_1, storage_key_1),
             Some(storage_value_1)
         );
-        assert_eq!(contract.read_contract_storage(&addr_2, storage_key_0), None);
-    })
+
+        next
+    };
+
+    contract.commit_changes(&next);
+    assert_eq!(contract.code_at(&addr_0), Some(code.to_vec()));
+    assert_eq!(contract.code_at(&addr_1), Some(code.to_vec()));
+    assert_eq!(contract.code_at(&addr_2), None);
+    assert_eq!(contract.nonce_of(&addr_0), nonce);
+    assert_eq!(contract.nonce_of(&addr_1), nonce);
+    assert_eq!(contract.nonce_of(&addr_2), zero);
+    assert_eq!(contract.balance_of(&addr_0), balance);
+    assert_eq!(contract.balance_of(&addr_1), balance);
+    assert_eq!(contract.balance_of(&addr_2), zero);
+    // assert_eq!(contract.read_contract_storage(&addr_0, storage_key_0), Some(storage_value_0));
+    assert_eq!(
+        contract.read_contract_storage(&addr_1, storage_key_0),
+        Some(storage_value_0)
+    );
+    assert_eq!(
+        contract.read_contract_storage(&addr_1, storage_key_1),
+        Some(storage_value_1)
+    );
+    assert_eq!(contract.read_contract_storage(&addr_2, storage_key_0), None);
 }

--- a/src/tests/test_utils.rs
+++ b/src/tests/test_utils.rs
@@ -24,18 +24,18 @@ fn get_context(input: Vec<u8>) -> VMContext {
     }
 }
 
-pub fn run_test<T>(attached_deposit: u128, test: T) -> ()
-where
-    T: FnOnce(&mut EvmContract) -> (),
-{
-    let mut context = get_context(vec![]);
-    context.attached_deposit = attached_deposit;
-    context.account_balance = attached_deposit;
-    testing_env!(context);
-    let mut contract = EvmContract::default();
-    test(&mut contract)
+pub fn initialize() -> EvmContract {
+    set_default_context();
+    return EvmContract::default();
 }
 
-pub fn reset_context() {
-    testing_env!(get_context(vec![]));
+pub fn set_default_context() {
+    let context = get_context(vec![]);
+    testing_env!(context);
+}
+
+pub fn attach_deposit(attached_deposit: u128) {
+    let mut context = get_context(vec![]);
+    context.attached_deposit = attached_deposit;
+    testing_env!(context);
 }

--- a/src/tests/test_utils.rs
+++ b/src/tests/test_utils.rs
@@ -15,7 +15,7 @@ fn get_context(input: Vec<u8>) -> VMContext {
         epoch_height: 0,
         account_balance: 0,
         account_locked_balance: 0,
-        storage_usage: 0,
+        storage_usage: 100000, // arbitrarily high number to avoid InconsistentStateError(IntegerOverflow) from resetting context params
         attached_deposit: 0,
         prepaid_gas: 2u64.pow(63),
         random_seed: vec![0, 1, 2],
@@ -34,8 +34,14 @@ pub fn set_default_context() {
     testing_env!(context);
 }
 
-pub fn attach_deposit(attached_deposit: u128) {
+pub fn tx_with_deposit<T, S>(attached_deposit: u128, mut tx: T) -> S
+where
+    T: FnMut() -> S, S: std::fmt::Debug
+{
     let mut context = get_context(vec![]);
     context.attached_deposit = attached_deposit;
     testing_env!(context);
+    let return_val = tx();
+    set_default_context();
+    return return_val;
 }


### PR DESCRIPTION
This is one of those really annoying whitespace PR's.

Thinking hopefully there's a rust trick I missed here, but really wanted to do something like the following, but `testing_env!` will not take the context as a mutable borrow, so we hand it off and are stuck with an outdated copy of context in our test. So I suspect when invoking `testing_env!` this many times without referencing the REAL updated context, things eventually get out of whack, and we find ourselves with a storage mismatch.  If I could deal with the real context out of thin air that would be great. Maybe there's a way to do this which doesn't get overly complicated? Otherwise this PR only makes a small change.
```
pub fn tx_with_deposit<T, S>(attached_deposit: u128, context: &mut VMContext, mut tx: T) -> S
where
    T: FnMut() -> S
{
    context.attached_deposit = attached_deposit;
    testing_env!(context.clone());
    let r = tx();
    set_default_context();
    return r;
}

test_utils::tx_with_deposit(100, &mut context, || {contract.add_near()});
```
```
`Err` value: InconsistentStateError(IntegerOverflow)', /Users/emilywilliams/.cargo/registry/src/github.com-1ecc6299db9ec823/near-sdk-0.11.0/src/environment/mocked_blockchain.rs:389:9
```