### PR TITLE
Implement precompiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,11 +525,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bn"
+version = "0.4.4"
+source = "git+https://github.com/paritytech/bn#635c4cdd560bc0c8b262e6bf809dc709da8bcd7e"
+dependencies = [
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -661,7 +684,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -818,6 +841,14 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1263,6 +1294,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "typenum 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1358,6 +1398,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "hex"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "hmac"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hmac-drbg"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "hostname"
@@ -1544,6 +1603,9 @@ dependencies = [
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "lazycell"
@@ -1573,6 +1635,21 @@ dependencies = [
  "cc 1.0.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.70 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libsecp256k1"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hmac-drbg 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1892,7 +1969,9 @@ name = "near-evm"
 version = "0.1.0"
 dependencies = [
  "actix 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bn 0.4.4 (git+https://github.com/paritytech/bn)",
  "borsh 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi-contract 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi-derive 8.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1903,12 +1982,16 @@ dependencies = [
  "keccak-hash 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy-static-include 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libsecp256k1 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
  "near-jsonrpc-client 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
  "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
  "near-sdk 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-bytes 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ripemd160 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2375,7 +2458,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2384,7 +2477,7 @@ version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2395,13 +2488,13 @@ dependencies = [
  "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2964,6 +3057,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hostname 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ripemd160"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-buffer 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3938,7 +4041,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 "checksum blake3 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "68df31bdf2bbb567e5adf8f21ac125dc0e897b1381e7b841f181521f06fc3134"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+"checksum block-buffer 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dbcf92448676f82bb7a334c58bbce8b0d43580fb5362a9d608b18879d12a3d31"
 "checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+"checksum bn 0.4.4 (git+https://github.com/paritytech/bn)" = "<none>"
 "checksum borsh 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9dada4c07fa726bc195503048581e7b1719407f7fbef82741f7b149d3921b3"
 "checksum borsh-derive 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "47c6bed3dd7695230e85bd51b6a4e4e4dc7550c1974a79c11e98a8a055211a61"
 "checksum borsh-derive-internal 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d34f80970434cd6524ae676b277d024b87dd93ecdd3f53bf470d61730dc6cb80"
@@ -3973,6 +4078,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26778518a7f6cffa1d25a44b602b62b979bd88adb9e99ffec546998cf3404839"
 "checksum derive_more 0.99.7 (registry+https://github.com/rust-lang/crates.io-index)" = "2127768764f1556535c01b5326ef94bd60ff08dcfbdc544d53e69ed155610f5d"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+"checksum digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 "checksum dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 "checksum dirs-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
 "checksum doc-comment 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
@@ -4022,6 +4128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+"checksum generic-array 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ac746a5f3bbfdadd6106868134545e684693d54d9d44f6e9588a7d54af0bf980"
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 "checksum gimli 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
 "checksum git-version 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "94918e83f1e01dedc2e361d00ce9487b14c58c7f40bab148026fa39d42cb41e2"
@@ -4034,6 +4141,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum hermit-abi 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+"checksum hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
+"checksum hmac-drbg 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c6e570451493f10f6581b48cdd530413b63ea9e780f544bfd3bdcaa0d89d1a7b"
 "checksum hostname 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
 "checksum http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
@@ -4061,6 +4170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum libc 0.2.70 (registry+https://github.com/rust-lang/crates.io-index)" = "3baa92041a6fec78c687fa0cc2b3fae8884f743d672cf551bed1d6dac6988d0f"
 "checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 "checksum librocksdb-sys 6.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "883213ae3d09bfc3d104aefe94b25ebb183b6f4d3a515b23b14817e1f4854005"
+"checksum libsecp256k1 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1fc1e2c808481a63dc6da2074752fdd4336a3c8fcc68b83db6f1fd5224ae7962"
 "checksum linked-hash-map 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum lock_api 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
@@ -4120,9 +4230,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum nom 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b471253da97532da4b61552249c521e01e736071f71c1a4f7ebbfbf0a06aad6"
 "checksum ntapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7a31937dea023539c72ddae0e3571deadc1414b300483fa7aaec176168cfa9d2"
 "checksum num-bigint 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+"checksum num-bigint 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b7f3fc75e3697059fb1bc465e3d8cca6cf92f56854f201158b3f9c77d5a3cfa0"
 "checksum num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
 "checksum num-rational 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
-"checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
+"checksum num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 "checksum num_cpus 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 "checksum object 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2"
 "checksum once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
@@ -4189,6 +4300,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex-syntax 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum resolv-conf 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "11834e137f3b14e309437a8276714eed3a80d1ef894869e510f2c0c0b98b9f4a"
+"checksum ripemd160 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7037e00ff78e861f53edd08ea4c4351fbf9b357145fdb791bc2f9a2236a33b45"
 "checksum rlp 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4a7d3f9bed94764eac15b8f14af59fac420c236adaff743b7bcc88e265cb4345"
 "checksum rocksdb 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "12069b106981c6103d3eab7dd1c86751482d0779a520b7c14954c8b586c1e643"
 "checksum rust-argon2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 [dependencies]
 evm = { git = "https://github.com/paritytech/parity-ethereum", rev = "eed630a002bbebed3a3097127f2483213ff52079" }
 vm = { git = "https://github.com/paritytech/parity-ethereum", rev = "eed630a002bbebed3a3097127f2483213ff52079" }
+bn = { git = "https://github.com/paritytech/bn", default-features = false }
 parity-bytes = "0.1.0"
 ethereum-types = "0.6.0"
 serde = { version = "1.0", features = ["derive"] }
@@ -19,6 +20,11 @@ near-sdk = "0.11.0"
 borsh = "0.6.0"
 rlp = "0.4.2"
 keccak-hash = "0.2.0"
+num-bigint = { version = "0.3", default-features = false }
+num-traits = "0.2.12"
+byteorder = "1.0"
+ripemd160 = "0.9.0"
+libsecp256k1 = "0.3.5"
 
 [dev-dependencies]
 lazy_static = "1.4"

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -1,0 +1,554 @@
+use byteorder::{BigEndian, LittleEndian, ByteOrder, ReadBytesExt};
+use ethereum_types::{Address, H256, U256};
+use num_bigint::BigUint;
+use num_traits::{One, Zero};
+
+use parity_bytes::BytesRef;
+use ripemd160::Digest;
+use std::{
+    cmp::{max, min},
+    io::{self, Read, Cursor},
+    mem::size_of,
+};
+use vm::{MessageCallResult, ReturnData};
+
+use near_sdk::env;
+
+pub static COUNT: u64 = 9;
+
+pub fn is_precompile(addr: &Address) -> bool {
+    *addr <= Address::from_low_u64_be(COUNT)
+}
+
+pub fn precompile(id: u64) -> Box<dyn Impl> {
+    match id {
+        1 => Box::new(EcRecover) as Box<dyn Impl>,
+        2 => Box::new(Sha256) as Box<dyn Impl>,
+        3 => Box::new(Ripemd160) as Box<dyn Impl>,
+        4 => Box::new(Identity) as Box<dyn Impl>,
+        5 => Box::new(ModexpImpl) as Box<dyn Impl>,
+        6 => Box::new(Bn128AddImpl) as Box<dyn Impl>,
+        7 => Box::new(Bn128MulImpl) as Box<dyn Impl>,
+        8 => Box::new(Bn128PairingImpl) as Box<dyn Impl>,
+        9 => Box::new(Blake2FImpl) as Box<dyn Impl>,
+        _ => panic!("Invalid builtin ID: {}", id),
+    }
+}
+
+pub fn process_precompile(addr: &Address, input: &[u8]) -> MessageCallResult {
+    let f = precompile(addr.to_low_u64_be());
+    let mut bytes = vec![];
+    let mut output = parity_bytes::BytesRef::Flexible(&mut bytes);
+
+    // mutates bytes
+    f.execute(input, &mut output)
+        .expect("No errors in precompiles");
+
+    let size = bytes.len();
+
+    MessageCallResult::Success(1_000_000_000.into(), ReturnData::new(bytes, 0, size))
+}
+
+/** the following is copied from ethcore/src/builtin.rs **/
+
+// Copyright 2015-2019 Parity Technologies (UK) Ltd.
+// This file is part of Parity Ethereum.
+
+// Parity Ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Ethereum.  If not, see <http://www.gnu.org/licenses/>.
+
+/// Execution error.
+#[derive(Debug)]
+pub struct Error(pub &'static str);
+
+impl From<&'static str> for Error {
+    fn from(val: &'static str) -> Self {
+        Error(val)
+    }
+}
+
+impl Into<vm::Error> for Error {
+    fn into(self) -> ::vm::Error {
+        vm::Error::BuiltIn(self.0)
+    }
+}
+#[derive(Debug)]
+struct EcRecover;
+
+#[derive(Debug)]
+struct Sha256;
+
+#[derive(Debug)]
+struct Ripemd160;
+
+#[derive(Debug)]
+struct Identity;
+
+#[derive(Debug)]
+struct ModexpImpl;
+
+#[derive(Debug)]
+struct Bn128AddImpl;
+
+#[derive(Debug)]
+struct Bn128MulImpl;
+
+#[derive(Debug)]
+struct Bn128PairingImpl;
+
+#[derive(Debug)]
+pub struct Blake2FImpl;
+
+/// Native implementation of a built-in contract.
+pub trait Impl: Send + Sync {
+    /// execute this built-in on the given input, writing to the given output.
+    fn execute(&self, input: &[u8], output: &mut BytesRef) -> Result<(), Error>;
+}
+
+impl Impl for Identity {
+    fn execute(&self, input: &[u8], output: &mut BytesRef) -> Result<(), Error> {
+        output.write(0, input);
+        Ok(())
+    }
+}
+
+impl Impl for EcRecover {
+	fn execute(&self, i: &[u8], output: &mut BytesRef) -> Result<(), Error> {
+        let len = min(i.len(), 128);
+
+		let mut input = [0; 128];
+		input[..len].copy_from_slice(&i[..len]);
+
+		let hash = secp256k1::Message::parse(&H256::from_slice(&input[0..32]).0);
+		let v = &input[32..64];
+		let r = &input[64..96];
+		let s = &input[96..128];
+
+		let bit = match v[31] {
+			27..=30 => v[31] - 27,
+			_ => { return Ok(()); },
+		};
+
+        let mut sig = [0u8; 64];
+        sig[..32].copy_from_slice(&r);
+        sig[32..].copy_from_slice(&s);
+        let s = secp256k1::Signature::parse(&sig);
+
+        if let Ok(rec_id) = secp256k1::RecoveryId::parse(bit) {
+            if let Ok(p) = secp256k1::recover(&hash, &s, &rec_id) {
+                // recover returns the 65-byte key, but addresses come from the raw 64-byte key
+                let r = env::keccak256(&p.serialize()[1..]);
+                output.write(0, &[0; 12]);
+                output.write(12, &r[12..]);
+            }
+        }
+
+		Ok(())
+	}
+}
+
+impl Impl for Sha256 {
+    fn execute(&self, input: &[u8], output: &mut BytesRef) -> Result<(), Error> {
+        let d = env::sha256(input);
+        output.write(0, &*d);
+        Ok(())
+    }
+}
+
+impl Impl for Ripemd160 {
+    fn execute(&self, input: &[u8], output: &mut BytesRef) -> Result<(), Error> {
+        let hash = ripemd160::Ripemd160::digest(input);
+        output.write(0, &[0; 12][..]);
+        output.write(12, &hash);
+        Ok(())
+    }
+}
+
+// calculate modexp: left-to-right binary exponentiation to keep multiplicands lower
+fn modexp(mut base: BigUint, exp: Vec<u8>, modulus: BigUint) -> BigUint {
+    const BITS_PER_DIGIT: usize = 8;
+
+    // n^m % 0 || n^m % 1
+    if modulus <= BigUint::one() {
+        return BigUint::zero();
+    }
+
+    // normalize exponent
+    let mut exp = exp.into_iter().skip_while(|d| *d == 0).peekable();
+
+    // n^0 % m
+    if exp.peek().is_none() {
+        return BigUint::one();
+    }
+
+    // 0^n % m, n > 0
+    if base.is_zero() {
+        return BigUint::zero();
+    }
+
+    base %= &modulus;
+
+    // Fast path for base divisible by modulus.
+    if base.is_zero() {
+        return BigUint::zero();
+    }
+
+    // Left-to-right binary exponentiation (Handbook of Applied Cryptography - Algorithm 14.79).
+    // http://www.cacr.math.uwaterloo.ca/hac/about/chap14.pdf
+    let mut result = BigUint::one();
+
+    for digit in exp {
+        let mut mask = 1 << (BITS_PER_DIGIT - 1);
+
+        for _ in 0..BITS_PER_DIGIT {
+            result = &result * &result % &modulus;
+
+            if digit & mask > 0 {
+                result = result * &base % &modulus;
+            }
+
+            mask >>= 1;
+        }
+    }
+
+    result
+}
+
+impl Impl for ModexpImpl {
+    fn execute(&self, input: &[u8], output: &mut BytesRef) -> Result<(), Error> {
+        let mut reader = input.chain(io::repeat(0));
+        let mut buf = [0; 32];
+
+        // read lengths as usize.
+        // ignoring the first 24 bytes might technically lead us to fall out of consensus,
+        // but so would running out of addressable memory!
+        let mut read_len = |reader: &mut io::Chain<&[u8], io::Repeat>| {
+            reader
+                .read_exact(&mut buf[..])
+                .expect("reading from zero-extended memory cannot fail; qed");
+            BigEndian::read_u64(&buf[24..]) as usize
+        };
+
+        let base_len = read_len(&mut reader);
+        let exp_len = read_len(&mut reader);
+        let mod_len = read_len(&mut reader);
+
+        // Gas formula allows arbitrary large exp_len when base and modulus are empty, so we need to handle empty base first.
+        let r = if base_len == 0 && mod_len == 0 {
+            BigUint::zero()
+        } else {
+            // read the numbers themselves.
+            let mut buf = vec![0; max(mod_len, max(base_len, exp_len))];
+            let mut read_num = |reader: &mut io::Chain<&[u8], io::Repeat>, len: usize| {
+                reader
+                    .read_exact(&mut buf[..len])
+                    .expect("reading from zero-extended memory cannot fail; qed");
+                BigUint::from_bytes_be(&buf[..len])
+            };
+
+            let base = read_num(&mut reader, base_len);
+
+            let mut exp_buf = vec![0; exp_len];
+            reader
+                .read_exact(&mut exp_buf[..exp_len])
+                .expect("reading from zero-extended memory cannot fail; qed");
+
+            let modulus = read_num(&mut reader, mod_len);
+
+            modexp(base, exp_buf, modulus)
+        };
+
+        // write output to given memory, left padded and same length as the modulus.
+        let bytes = r.to_bytes_be();
+
+        // always true except in the case of zero-length modulus, which leads to
+        // output of length and value 1.
+        if bytes.len() <= mod_len {
+            let res_start = mod_len - bytes.len();
+            output.write(res_start, &bytes);
+        }
+
+        Ok(())
+    }
+}
+
+fn read_fr(reader: &mut io::Chain<&[u8], io::Repeat>) -> Result<::bn::Fr, Error> {
+	let mut buf = [0u8; 32];
+
+	reader.read_exact(&mut buf[..]).expect("reading from zero-extended memory cannot fail; qed");
+	::bn::Fr::from_slice(&buf[0..32]).map_err(|_| Error::from("Invalid field element"))
+}
+
+fn read_point(reader: &mut io::Chain<&[u8], io::Repeat>) -> Result<::bn::G1, Error> {
+	use bn::{Fq, AffineG1, G1, Group};
+
+	let mut buf = [0u8; 32];
+
+	reader.read_exact(&mut buf[..]).expect("reading from zero-extended memory cannot fail; qed");
+	let px = Fq::from_slice(&buf[0..32]).map_err(|_| Error::from("Invalid point x coordinate"))?;
+
+	reader.read_exact(&mut buf[..]).expect("reading from zero-extended memory cannot fail; qed");
+	let py = Fq::from_slice(&buf[0..32]).map_err(|_| Error::from("Invalid point y coordinate"))?;
+	Ok(
+		if px == Fq::zero() && py == Fq::zero() {
+			G1::zero()
+		} else {
+			AffineG1::new(px, py).map_err(|_| Error::from("Invalid curve point"))?.into()
+		}
+	)
+}
+
+impl Impl for Bn128AddImpl {
+	// Can fail if any of the 2 points does not belong the bn128 curve
+	fn execute(&self, input: &[u8], output: &mut BytesRef) -> Result<(), Error> {
+		use bn::AffineG1;
+
+		let mut padded_input = input.chain(io::repeat(0));
+		let p1 = read_point(&mut padded_input)?;
+		let p2 = read_point(&mut padded_input)?;
+
+		let mut write_buf = [0u8; 64];
+		if let Some(sum) = AffineG1::from_jacobian(p1 + p2) {
+			// point not at infinity
+			sum.x().to_big_endian(&mut write_buf[0..32]).expect("Cannot fail since 0..32 is 32-byte length");
+			sum.y().to_big_endian(&mut write_buf[32..64]).expect("Cannot fail since 32..64 is 32-byte length");
+		}
+		output.write(0, &write_buf);
+
+		Ok(())
+	}
+}
+
+impl Impl for Bn128MulImpl {
+	// Can fail if first paramter (bn128 curve point) does not actually belong to the curve
+	fn execute(&self, input: &[u8], output: &mut BytesRef) -> Result<(), Error> {
+		use bn::AffineG1;
+
+		let mut padded_input = input.chain(io::repeat(0));
+		let p = read_point(&mut padded_input)?;
+		let fr = read_fr(&mut padded_input)?;
+
+		let mut write_buf = [0u8; 64];
+		if let Some(sum) = AffineG1::from_jacobian(p * fr) {
+			// point not at infinity
+			sum.x().to_big_endian(&mut write_buf[0..32]).expect("Cannot fail since 0..32 is 32-byte length");
+			sum.y().to_big_endian(&mut write_buf[32..64]).expect("Cannot fail since 32..64 is 32-byte length");
+		}
+		output.write(0, &write_buf);
+		Ok(())
+	}
+}
+
+impl Impl for Bn128PairingImpl {
+	/// Can fail if:
+	///     - input length is not a multiple of 192
+	///     - any of odd points does not belong to bn128 curve
+	///     - any of even points does not belong to the twisted bn128 curve over the field F_p^2 = F_p[i] / (i^2 + 1)
+	fn execute(&self, input: &[u8], output: &mut BytesRef) -> Result<(), Error> {
+		if input.len() % 192 != 0 {
+			return Err("Invalid input length, must be multiple of 192 (3 * (32*2))".into())
+		}
+
+		if let Err(err) = self.execute_with_error(input, output) {
+			panic!("Pairining error: {:?}", err);
+		}
+		Ok(())
+	}
+}
+
+impl Bn128PairingImpl {
+	fn execute_with_error(&self, input: &[u8], output: &mut BytesRef) -> Result<(), Error> {
+		use bn::{AffineG1, AffineG2, Fq, Fq2, pairing, G1, G2, Gt, Group};
+
+		let elements = input.len() / 192; // (a, b_a, b_b - each 64-byte affine coordinates)
+		let ret_val = if input.is_empty() {
+			U256::one()
+		} else {
+			let mut vals = Vec::new();
+			for idx in 0..elements {
+				let a_x = Fq::from_slice(&input[idx*192..idx*192+32])
+					.map_err(|_| Error::from("Invalid a argument x coordinate"))?;
+
+				let a_y = Fq::from_slice(&input[idx*192+32..idx*192+64])
+					.map_err(|_| Error::from("Invalid a argument y coordinate"))?;
+
+				let b_a_y = Fq::from_slice(&input[idx*192+64..idx*192+96])
+					.map_err(|_| Error::from("Invalid b argument imaginary coeff x coordinate"))?;
+
+				let b_a_x = Fq::from_slice(&input[idx*192+96..idx*192+128])
+					.map_err(|_| Error::from("Invalid b argument imaginary coeff y coordinate"))?;
+
+				let b_b_y = Fq::from_slice(&input[idx*192+128..idx*192+160])
+					.map_err(|_| Error::from("Invalid b argument real coeff x coordinate"))?;
+
+				let b_b_x = Fq::from_slice(&input[idx*192+160..idx*192+192])
+					.map_err(|_| Error::from("Invalid b argument real coeff y coordinate"))?;
+
+				let b_a = Fq2::new(b_a_x, b_a_y);
+				let b_b = Fq2::new(b_b_x, b_b_y);
+				let b = if b_a.is_zero() && b_b.is_zero() {
+					G2::zero()
+				} else {
+					G2::from(AffineG2::new(b_a, b_b).map_err(|_| Error::from("Invalid b argument - not on curve"))?)
+				};
+				let a = if a_x.is_zero() && a_y.is_zero() {
+					G1::zero()
+				} else {
+					G1::from(AffineG1::new(a_x, a_y).map_err(|_| Error::from("Invalid a argument - not on curve"))?)
+				};
+				vals.push((a, b));
+			};
+
+			let mul = vals.into_iter().fold(Gt::one(), |s, (a, b)| s * pairing(a, b));
+
+			if mul == Gt::one() {
+				U256::one()
+			} else {
+				U256::zero()
+			}
+		};
+
+		let mut buf = [0u8; 32];
+		ret_val.to_big_endian(&mut buf);
+		output.write(0, &buf);
+
+		Ok(())
+	}
+}
+
+/// The precomputed values for BLAKE2b [from the spec](https://tools.ietf.org/html/rfc7693#section-2.7)
+/// There are 10 16-byte arrays - one for each round
+/// the entries are calculated from the sigma constants.
+const SIGMA: [[usize; 16]; 10] = [
+	[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+	[14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3],
+	[11, 8, 12, 0, 5, 2, 15, 13, 10, 14, 3, 6, 7, 1, 9, 4],
+	[7, 9, 3, 1, 13, 12, 11, 14, 2, 6, 5, 10, 4, 0, 15, 8],
+	[9, 0, 5, 7, 2, 4, 10, 15, 14, 1, 11, 12, 6, 8, 3, 13],
+	[2, 12, 6, 10, 0, 11, 8, 3, 4, 13, 7, 5, 15, 14, 1, 9],
+	[12, 5, 1, 15, 14, 13, 4, 10, 0, 7, 6, 3, 9, 2, 8, 11],
+	[13, 11, 7, 14, 12, 1, 3, 9, 5, 0, 15, 4, 8, 6, 2, 10],
+	[6, 15, 14, 9, 11, 3, 0, 8, 12, 2, 13, 7, 1, 4, 10, 5],
+	[10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0],
+];
+
+
+/// IV is the initialization vector for BLAKE2b. See https://tools.ietf.org/html/rfc7693#section-2.6
+/// for details.
+const IV: [u64; 8] = [
+	0x6a09e667f3bcc908, 0xbb67ae8584caa73b, 0x3c6ef372fe94f82b, 0xa54ff53a5f1d36f1,
+	0x510e527fade682d1, 0x9b05688c2b3e6c1f, 0x1f83d9abfb41bd6b, 0x5be0cd19137e2179,
+];
+
+#[inline(always)]
+#[allow(clippy::many_single_char_names)]
+fn g(v: &mut [u64], a: usize, b: usize, c: usize, d: usize, x: u64, y: u64) {
+	v[a] = v[a].wrapping_add(v[b]).wrapping_add(x);
+	v[d] = (v[d] ^ v[a]).rotate_right(32);
+	v[c] = v[c].wrapping_add(v[d]);
+	v[b] = (v[b] ^ v[c]).rotate_right(24);
+
+	v[a] = v[a].wrapping_add(v[b]).wrapping_add(y);
+	v[d] = (v[d] ^ v[a]).rotate_right(16);
+	v[c] = v[c].wrapping_add(v[d]);
+	v[b] = (v[b] ^ v[c]).rotate_right(63);
+}
+
+/// The Blake2b compression function F. See https://tools.ietf.org/html/rfc7693#section-3.2
+/// Takes as an argument the state vector `h`, message block vector `m`, offset counter `t`, final
+/// block indicator flag `f`, and number of rounds `rounds`. The state vector provided as the first
+/// parameter is modified by the function.
+#[allow(clippy::many_single_char_names)]
+pub fn compress(h: &mut [u64; 8], m: [u64; 16], t: [u64; 2], f: bool, rounds: usize) {
+	let mut v = [0u64; 16];
+	v[..8].copy_from_slice(h);    // First half from state.
+	v[8..].copy_from_slice(&IV);  // Second half from IV.
+
+	v[12] ^= t[0];
+	v[13] ^= t[1];
+
+	if f {
+		v[14] = !v[14]; // Invert all bits if the last-block-flag is set.
+	}
+
+	for i in 0..rounds {
+		// Message word selection permutation for this round.
+		let s = &SIGMA[i % 10];
+		g(&mut v, 0, 4, 8, 12, m[s[0]], m[s[1]]);
+		g(&mut v, 1, 5, 9, 13, m[s[2]], m[s[3]]);
+		g(&mut v, 2, 6, 10, 14, m[s[4]], m[s[5]]);
+		g(&mut v, 3, 7, 11, 15, m[s[6]], m[s[7]]);
+
+		g(&mut v, 0, 5, 10, 15, m[s[8]], m[s[9]]);
+		g(&mut v, 1, 6, 11, 12, m[s[10]], m[s[11]]);
+		g(&mut v, 2, 7, 8, 13, m[s[12]], m[s[13]]);
+		g(&mut v, 3, 4, 9, 14, m[s[14]], m[s[15]]);
+	}
+
+	for i in 0..8 {
+		h[i] ^= v[i] ^ v[i + 8];
+	}
+}
+
+impl Impl for Blake2FImpl {
+	/// Format of `input`:
+	/// [4 bytes for rounds][64 bytes for h][128 bytes for m][8 bytes for t_0][8 bytes for t_1][1 byte for f]
+	fn execute(&self, input: &[u8], output: &mut BytesRef) -> Result<(), Error> {
+		const BLAKE2_F_ARG_LEN: usize = 213;
+		const PROOF: &str = "Checked the length of the input above; qed";
+
+		if input.len() != BLAKE2_F_ARG_LEN {
+			panic!("input length for Blake2 F precompile should be exactly 213 bytes, was {}", input.len());
+			// return Err("input length for Blake2 F precompile should be exactly 213 bytes")
+		}
+
+		let mut cursor = Cursor::new(input);
+		let rounds = cursor.read_u32::<BigEndian>().expect(PROOF);
+
+		// state vector, h
+		let mut h = [0u64; 8];
+		for state_word in &mut h {
+			*state_word = cursor.read_u64::<byteorder::LittleEndian>().expect(PROOF);
+		}
+
+		// message block vector, m
+		let mut m = [0u64; 16];
+		for msg_word in &mut m {
+			*msg_word = cursor.read_u64::<LittleEndian>().expect(PROOF);
+		}
+
+		// 2w-bit offset counter, t
+		let t = [
+			cursor.read_u64::<LittleEndian>().expect(PROOF),
+			cursor.read_u64::<LittleEndian>().expect(PROOF),
+		];
+
+		// final block indicator flag, "f"
+		let f = match input.last() {
+				Some(1) => true,
+				Some(0) => false,
+				_ => {
+					panic!("incorrect final block indicator flag, was: {:?}", input.last());
+				}
+			};
+
+		compress(&mut h, m, t, f, rounds as usize);
+
+		let mut output_buf = [0u8; 8 * size_of::<u64>()];
+		for (i, state_word) in h.iter().enumerate() {
+			output_buf[i*8..(i+1)*8].copy_from_slice(&state_word.to_le_bytes());
+		}
+		output.write(0, &output_buf[..]);
+		Ok(())
+	}
+}

--- a/src/evm_state.rs
+++ b/src/evm_state.rs
@@ -152,7 +152,9 @@ impl StateStore {
 impl EvmState for StateStore {
     fn code_at(&self, address: &Address) -> Option<Vec<u8>> {
         let internal_addr = utils::evm_account_to_internal_address(*address);
-        if self.self_destructs.contains(&internal_addr) { None } else {
+        if self.self_destructs.contains(&internal_addr) {
+            None
+        } else {
             self.code.get(&internal_addr).cloned()
         }
     }
@@ -231,7 +233,9 @@ impl SubState<'_> {
 impl EvmState for SubState<'_> {
     fn code_at(&self, address: &Address) -> Option<Vec<u8>> {
         let internal_addr = utils::evm_account_to_internal_address(*address);
-        if self.state.self_destructs.contains(&internal_addr) { None } else {
+        if self.state.self_destructs.contains(&internal_addr) {
+            None
+        } else {
             self.state
                 .code
                 .get(&internal_addr)
@@ -264,7 +268,6 @@ impl EvmState for SubState<'_> {
                 .nonces
                 .get(&address)
                 .map_or_else(|| self.parent._nonce_of(address), |k| *k)
-
         }
     }
 
@@ -500,10 +503,7 @@ mod test {
             assert_eq!(sub_1.code_at(&addr_1), None);
             assert_eq!(sub_1.nonce_of(&addr_1), zero);
             assert_eq!(sub_1.balance_of(&addr_1), balance_1);
-            assert_eq!(
-                sub_1.read_contract_storage(&addr_1, storage_key_1),
-                None
-            );
+            assert_eq!(sub_1.read_contract_storage(&addr_1, storage_key_1), None);
 
             next
         };
@@ -523,9 +523,6 @@ mod test {
             top.read_contract_storage(&addr_0, storage_key_0),
             Some(storage_value_0)
         );
-        assert_eq!(
-            top.read_contract_storage(&addr_1, storage_key_1),
-            None
-        );
+        assert_eq!(top.read_contract_storage(&addr_1, storage_key_1), None);
     }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -51,10 +51,10 @@ pub fn deploy_code<T: EvmState>(
         state.set_code(address, &return_data.to_vec());
     } else {
         // TODO: consider whether this should panic.
-        panic!(
-            format!("Contract failed to deploy, with message: [{}].",
-            hex::encode(&return_data.to_vec()))
-        )
+        panic!(format!(
+            "Contract failed to deploy, with message: [{}].",
+            hex::encode(&return_data.to_vec())
+        ))
     }
 }
 
@@ -105,6 +105,7 @@ pub fn _create<T: EvmState>(
     (result.ok().unwrap().ok(), Some(store))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn call<T: EvmState>(
     state: &mut T,
     origin: &Address,
@@ -177,6 +178,7 @@ pub fn static_call<T: EvmState>(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_and_commit_if_success<T: EvmState>(
     state: &mut T,
     origin: &Address,
@@ -231,6 +233,7 @@ fn run_and_commit_if_success<T: EvmState>(
 }
 
 /// Runs the interpreter. Produces state diffs
+#[allow(clippy::too_many_arguments)]
 fn run_against_state<T: EvmState>(
     state: &mut T,
     origin: &Address,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ extern crate lazy_static_include;
 #[macro_use]
 extern crate lazy_static;
 
+mod builtins;
 mod evm_state;
 mod interpreter;
 mod near_ext;
@@ -398,7 +399,7 @@ impl EvmContract {
     }
 }
 /// implement #[near_bindgen_macro] functionality for view_call_contract except for attached_deposit
-#[cfg(target_arch="wasm32")]
+#[cfg(target_arch = "wasm32")]
 #[no_mangle]
 pub extern "C" fn view_call_contract() {
     near_sdk::env::setup_panic_hook();
@@ -411,15 +412,22 @@ pub extern "C" fn view_call_contract() {
         sender: String,
         value: Balance,
     }
-    let Input { contract_address, encoded_input,sender, value }: Input = serde_json::from_slice(
-         &near_sdk::env::input().expect("Expected input since method has arguments.")
-    ).expect("Failed to deserialize input from JSON.");
+    let Input {
+        contract_address,
+        encoded_input,
+        sender,
+        value,
+    }: Input = serde_json::from_slice(
+        &near_sdk::env::input().expect("Expected input since method has arguments."),
+    )
+    .expect("Failed to deserialize input from JSON.");
 
     let mut contract: EvmContract = near_sdk::env::state_read().unwrap_or_default();
-    let result = contract.view_call_contract(contract_address, encoded_input,sender, value, );
-    let result = serde_json::to_vec(&result).expect("Failed to serialize the return value using JSON.");
+    let result = contract.view_call_contract(contract_address, encoded_input, sender, value);
+    let result =
+        serde_json::to_vec(&result).expect("Failed to serialize the return value using JSON.");
     near_sdk::env::value_return(&result);
- }
+}
 
 impl EvmContract {
     fn commit_code(&mut self, other: &HashMap<[u8; 20], Vec<u8>>) {

--- a/src/near_ext.rs
+++ b/src/near_ext.rs
@@ -173,6 +173,11 @@ impl<'a> vm::Ext for NearExt<'a> {
             panic!("MutableCallInStaticContext")
         }
 
+        // hijack builtins
+        if crate::builtins::is_precompile(receive_address) {
+            return Ok(crate::builtins::process_precompile(receive_address, data));
+        }
+
         let result = match call_type {
             CallType::None => {
                 // Can stay unimplemented

--- a/src/tests/contracts/SolTests.sol
+++ b/src/tests/contracts/SolTests.sol
@@ -39,6 +39,24 @@ contract SolTests is ExposesBalance {
         emit SomeEvent(_aNumber);
         return true;
     }
+
+    function precompileTest() public pure {
+        require(sha256("") == hex"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "sha2 digest mismatch");
+        require(ripemd160("") == hex"9c1185a5c5e9fc54612808977ee8f548b2258d31", "rmd160 digest mismatch");
+
+        // signed with hex"2222222222222222222222222222222222222222222222222222222222222222"
+        address addr = ecrecover(
+            hex"1111111111111111111111111111111111111111111111111111111111111111",
+            27,
+            hex"b9f0bb08640d3c1c00761cdd0121209268f6fd3816bc98b9e6f3cc77bf82b698", // r
+            hex"12ac7a61788a0fdc0e19180f14c945a8e1088a27d92a74dce81c0981fb644744"  // s
+        );
+
+        require(
+            addr == 0x1563915e194D8CfBA1943570603F7606A3115508,
+            "ecrecover mismatch"
+        );
+    }
 }
 
 contract SubContract is ExposesBalance {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,6 +1,6 @@
-use ethabi_contract::use_contract;
-use ethereum_types::{Address, U256, H256};
 use crate::{evm_state::*, utils};
+use ethabi_contract::use_contract;
+use ethereum_types::{Address, H256, U256};
 
 mod cryptozombies;
 mod test_utils;
@@ -66,7 +66,6 @@ fn test_deploy_with_nonce() {
 fn test_failed_deploy_returns_error() {
     let mut contract = test_utils::initialize();
     contract.deploy_code(CONSTRUCTOR_TEST.to_string());
-
 }
 
 #[test]
@@ -108,6 +107,18 @@ fn test_deploy_and_transfer() {
     let sub_addr = raw[24..64].to_string();
     assert_eq!(contract.balance_of_evm_address(test_addr).0, 100);
     assert_eq!(contract.balance_of_evm_address(sub_addr).0, 100);
+}
+
+#[test]
+fn test_precompiles() {
+    let mut contract = test_utils::initialize();
+    let test_addr = test_utils::tx_with_deposit(100, || {
+        contract.deploy_code(TEST.to_string())
+    });
+
+    let (input, _) = soltest::functions::precompile_test::call();
+    let raw = contract.call_contract(test_addr.clone(), hex::encode(input.clone()));
+    assert_eq!(raw, "");
 }
 
 #[test]


### PR DESCRIPTION
As precompiles aren't a native part of the EVM we need to hijack calls to specific addresses. This PR adds a sensible place to do that.