### PR TITLE
Update nearcore dependencies to stable branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,25 +557,25 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "borsh-derive 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh-derive 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "borsh-derive-internal 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh-schema-derive-internal 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh-derive-internal 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh-schema-derive-internal 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "borsh-derive-internal"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "borsh-schema-derive-internal"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1819,7 +1819,7 @@ dependencies = [
 [[package]]
 name = "near-actix-utils"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#442998a79b9f9556c94aec2174eb858b31c0b4ee"
+source = "git+https://github.com/nearprotocol/nearcore?branch=stable#ebe21b338f17809b5ff6bc0ff2c0fbd5f5616bbb"
 dependencies = [
  "actix 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1827,24 +1827,24 @@ dependencies = [
 [[package]]
 name = "near-chain"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#442998a79b9f9556c94aec2174eb858b31c0b4ee"
+source = "git+https://github.com/nearprotocol/nearcore?branch=stable#ebe21b338f17809b5ff6bc0ff2c0fbd5f5616bbb"
 dependencies = [
- "borsh 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cached 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-chain-configs 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-metrics 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-pool 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-store 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
+ "near-chain-configs 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-metrics 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-pool 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-store 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
  "num-rational 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocksdb 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocksdb 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1852,13 +1852,13 @@ dependencies = [
 [[package]]
 name = "near-chain-configs"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#442998a79b9f9556c94aec2174eb858b31c0b4ee"
+source = "git+https://github.com/nearprotocol/nearcore?branch=stable#ebe21b338f17809b5ff6bc0ff2c0fbd5f5616bbb"
 dependencies = [
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.99.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-runtime-configs 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
+ "near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-runtime-configs 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
  "num-rational 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1868,20 +1868,20 @@ dependencies = [
 [[package]]
 name = "near-chunks"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#442998a79b9f9556c94aec2174eb858b31c0b4ee"
+source = "git+https://github.com/nearprotocol/nearcore?branch=stable#ebe21b338f17809b5ff6bc0ff2c0fbd5f5616bbb"
 dependencies = [
  "actix 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cached 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-chain 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-network 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-pool 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-store 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
+ "near-chain 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-network 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-pool 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-store 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "reed-solomon-erasure 4.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1890,44 +1890,44 @@ dependencies = [
 [[package]]
 name = "near-client"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#442998a79b9f9556c94aec2174eb858b31c0b4ee"
+source = "git+https://github.com/nearprotocol/nearcore?branch=stable#ebe21b338f17809b5ff6bc0ff2c0fbd5f5616bbb"
 dependencies = [
  "actix 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cached 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-chain 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-chain-configs 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-chunks 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-metrics 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-network 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-pool 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-store 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-telemetry 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
+ "near-chain 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-chain-configs 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-chunks 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-metrics 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-network 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-pool 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-store 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-telemetry 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
  "num-rational 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "reed-solomon-erasure 4.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocksdb 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocksdb 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sysinfo 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sysinfo 0.14.3 (git+https://github.com/near/sysinfo?rev=3cb97ee79a02754407d2f0f63628f247d7c65e7b)",
 ]
 
 [[package]]
 name = "near-crypto"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#442998a79b9f9556c94aec2174eb858b31c0b4ee"
+source = "git+https://github.com/nearprotocol/nearcore?branch=stable#ebe21b338f17809b5ff6bc0ff2c0fbd5f5616bbb"
 dependencies = [
  "arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "c2-chacha 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1947,21 +1947,22 @@ dependencies = [
 [[package]]
 name = "near-epoch-manager"
 version = "0.0.1"
-source = "git+https://github.com/nearprotocol/nearcore#442998a79b9f9556c94aec2174eb858b31c0b4ee"
+source = "git+https://github.com/nearprotocol/nearcore?branch=stable#ebe21b338f17809b5ff6bc0ff2c0fbd5f5616bbb"
 dependencies = [
- "borsh 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cached 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-chain 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-store 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
+ "near-chain 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-store 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
  "num-rational 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitive-types 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smart-default 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1970,7 +1971,7 @@ version = "0.1.0"
 dependencies = [
  "actix 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bn 0.4.4 (git+https://github.com/paritytech/bn)",
- "borsh 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi-contract 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1983,9 +1984,9 @@ dependencies = [
  "lazy-static-include 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-jsonrpc-client 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
+ "near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-jsonrpc-client 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
  "near-sdk 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1995,29 +1996,29 @@ dependencies = [
  "rlp 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
- "testlib 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
+ "testlib 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
  "vm 0.1.0 (git+https://github.com/paritytech/parity-ethereum?rev=eed630a002bbebed3a3097127f2483213ff52079)",
 ]
 
 [[package]]
 name = "near-jsonrpc"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#442998a79b9f9556c94aec2174eb858b31c0b4ee"
+source = "git+https://github.com/nearprotocol/nearcore?branch=stable#ebe21b338f17809b5ff6bc0ff2c0fbd5f5616bbb"
 dependencies = [
  "actix 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-cors 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-chain-configs 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-client 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-jsonrpc-client 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-metrics 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-network 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-rpc-error-macro 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
+ "near-chain-configs 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-client 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-jsonrpc-client 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-metrics 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-network 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-rpc-error-macro 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
  "prometheus 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2028,11 +2029,11 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#442998a79b9f9556c94aec2174eb858b31c0b4ee"
+source = "git+https://github.com/nearprotocol/nearcore?branch=stable#ebe21b338f17809b5ff6bc0ff2c0fbd5f5616bbb"
 dependencies = [
  "actix-web 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
+ "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2041,16 +2042,16 @@ dependencies = [
 [[package]]
 name = "near-logger-utils"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#442998a79b9f9556c94aec2174eb858b31c0b4ee"
+source = "git+https://github.com/nearprotocol/nearcore?branch=stable#ebe21b338f17809b5ff6bc0ff2c0fbd5f5616bbb"
 dependencies = [
- "near-actix-utils 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
+ "near-actix-utils 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
  "tracing-subscriber 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "near-metrics"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#442998a79b9f9556c94aec2174eb858b31c0b4ee"
+source = "git+https://github.com/nearprotocol/nearcore?branch=stable#ebe21b338f17809b5ff6bc0ff2c0fbd5f5616bbb"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2060,10 +2061,10 @@ dependencies = [
 [[package]]
 name = "near-network"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#442998a79b9f9556c94aec2174eb858b31c0b4ee"
+source = "git+https://github.com/nearprotocol/nearcore?branch=stable#ebe21b338f17809b5ff6bc0ff2c0fbd5f5616bbb"
 dependencies = [
  "actix 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cached 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2071,12 +2072,12 @@ dependencies = [
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-chain 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-chain-configs 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-metrics 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-store 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
+ "near-chain 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-chain-configs 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-metrics 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-store 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2088,21 +2089,21 @@ dependencies = [
 [[package]]
 name = "near-pool"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#442998a79b9f9556c94aec2174eb858b31c0b4ee"
+source = "git+https://github.com/nearprotocol/nearcore?branch=stable#ebe21b338f17809b5ff6bc0ff2c0fbd5f5616bbb"
 dependencies = [
- "borsh 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
+ "borsh 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "near-primitives"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#442998a79b9f9556c94aec2174eb858b31c0b4ee"
+source = "git+https://github.com/nearprotocol/nearcore?branch=stable#ebe21b338f17809b5ff6bc0ff2c0fbd5f5616bbb"
 dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2111,9 +2112,9 @@ dependencies = [
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-rpc-error-macro 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-vm-errors 0.9.0 (git+https://github.com/nearprotocol/nearcore)",
+ "near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-rpc-error-macro 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-vm-errors 0.9.1 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
  "num-rational 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "reed-solomon-erasure 4.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2129,7 +2130,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-core"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#442998a79b9f9556c94aec2174eb858b31c0b4ee"
+source = "git+https://github.com/nearprotocol/nearcore?branch=stable#ebe21b338f17809b5ff6bc0ff2c0fbd5f5616bbb"
 dependencies = [
  "proc-macro2 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2152,9 +2153,9 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-macro"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#442998a79b9f9556c94aec2174eb858b31c0b4ee"
+source = "git+https://github.com/nearprotocol/nearcore?branch=stable#ebe21b338f17809b5ff6bc0ff2c0fbd5f5616bbb"
 dependencies = [
- "near-rpc-error-core 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
+ "near-rpc-error-core 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
  "proc-macro2 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2178,18 +2179,18 @@ dependencies = [
 [[package]]
 name = "near-runtime-configs"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#442998a79b9f9556c94aec2174eb858b31c0b4ee"
+source = "git+https://github.com/nearprotocol/nearcore?branch=stable#ebe21b338f17809b5ff6bc0ff2c0fbd5f5616bbb"
 dependencies = [
- "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-runtime-fees 0.9.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-vm-logic 0.9.0 (git+https://github.com/nearprotocol/nearcore)",
+ "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-runtime-fees 0.9.1 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-vm-logic 0.9.1 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "near-runtime-fees"
-version = "0.9.0"
-source = "git+https://github.com/nearprotocol/nearcore#442998a79b9f9556c94aec2174eb858b31c0b4ee"
+version = "0.9.1"
+source = "git+https://github.com/nearprotocol/nearcore?branch=stable#ebe21b338f17809b5ff6bc0ff2c0fbd5f5616bbb"
 dependencies = [
  "num-rational 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2210,7 +2211,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "near-runtime-fees 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "near-sdk-macros 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2243,26 +2244,26 @@ dependencies = [
 [[package]]
 name = "near-store"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#442998a79b9f9556c94aec2174eb858b31c0b4ee"
+source = "git+https://github.com/nearprotocol/nearcore?branch=stable#ebe21b338f17809b5ff6bc0ff2c0fbd5f5616bbb"
 dependencies = [
- "borsh 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cached 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.99.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "elastic-array 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-chain-configs 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
+ "near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
  "num_cpus 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocksdb 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocksdb 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "near-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#442998a79b9f9556c94aec2174eb858b31c0b4ee"
+source = "git+https://github.com/nearprotocol/nearcore?branch=stable#ebe21b338f17809b5ff6bc0ff2c0fbd5f5616bbb"
 dependencies = [
  "actix 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2276,11 +2277,11 @@ dependencies = [
 
 [[package]]
 name = "near-vm-errors"
-version = "0.9.0"
-source = "git+https://github.com/nearprotocol/nearcore#442998a79b9f9556c94aec2174eb858b31c0b4ee"
+version = "0.9.1"
+source = "git+https://github.com/nearprotocol/nearcore?branch=stable#ebe21b338f17809b5ff6bc0ff2c0fbd5f5616bbb"
 dependencies = [
- "borsh 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-rpc-error-macro 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
+ "borsh 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "near-rpc-error-macro 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2289,21 +2290,21 @@ name = "near-vm-errors"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "borsh 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "near-rpc-error-macro 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "near-vm-logic"
-version = "0.9.0"
-source = "git+https://github.com/nearprotocol/nearcore#442998a79b9f9556c94aec2174eb858b31c0b4ee"
+version = "0.9.1"
+source = "git+https://github.com/nearprotocol/nearcore?branch=stable#ebe21b338f17809b5ff6bc0ff2c0fbd5f5616bbb"
 dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-runtime-fees 0.9.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-vm-errors 0.9.0 (git+https://github.com/nearprotocol/nearcore)",
+ "near-runtime-fees 0.9.1 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-vm-errors 0.9.1 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2326,13 +2327,13 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "0.9.0"
-source = "git+https://github.com/nearprotocol/nearcore#442998a79b9f9556c94aec2174eb858b31c0b4ee"
+version = "0.9.1"
+source = "git+https://github.com/nearprotocol/nearcore?branch=stable#ebe21b338f17809b5ff6bc0ff2c0fbd5f5616bbb"
 dependencies = [
  "cached 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-runtime-fees 0.9.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-vm-errors 0.9.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-vm-logic 0.9.0 (git+https://github.com/nearprotocol/nearcore)",
+ "near-runtime-fees 0.9.1 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-vm-errors 0.9.1 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-vm-logic 0.9.1 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
  "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pwasm-utils 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-runtime 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2341,11 +2342,11 @@ dependencies = [
 
 [[package]]
 name = "neard"
-version = "0.4.13"
-source = "git+https://github.com/nearprotocol/nearcore#442998a79b9f9556c94aec2174eb858b31c0b4ee"
+version = "1.0.0"
+source = "git+https://github.com/nearprotocol/nearcore?branch=stable#ebe21b338f17809b5ff6bc0ff2c0fbd5f5616bbb"
 dependencies = [
  "actix 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2355,24 +2356,24 @@ dependencies = [
  "git-version 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-actix-utils 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-chain 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-chain-configs 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-chunks 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-client 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-epoch-manager 0.0.1 (git+https://github.com/nearprotocol/nearcore)",
- "near-jsonrpc 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-network 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-pool 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-runtime-configs 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-store 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-telemetry 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "node-runtime 0.9.0 (git+https://github.com/nearprotocol/nearcore)",
+ "near-actix-utils 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-chain 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-chain-configs 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-chunks 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-client 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-epoch-manager 0.0.1 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-jsonrpc 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-network 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-pool 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-runtime-configs 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-store 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-telemetry 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "node-runtime 0.9.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
  "num-rational 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocksdb 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocksdb 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2404,25 +2405,25 @@ dependencies = [
 [[package]]
 name = "node-runtime"
 version = "0.9.0"
-source = "git+https://github.com/nearprotocol/nearcore#442998a79b9f9556c94aec2174eb858b31c0b4ee"
+source = "git+https://github.com/nearprotocol/nearcore?branch=stable#ebe21b338f17809b5ff6bc0ff2c0fbd5f5616bbb"
 dependencies = [
- "borsh 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cached 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-metrics 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-runtime-configs 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-runtime-fees 0.9.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-store 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-vm-errors 0.9.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-vm-logic 0.9.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-vm-runner 0.9.0 (git+https://github.com/nearprotocol/nearcore)",
+ "near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-metrics 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-runtime-configs 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-runtime-fees 0.9.1 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-store 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-vm-errors 0.9.1 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-vm-logic 0.9.1 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-vm-runner 0.9.1 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
  "num-rational 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocksdb 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocksdb 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3079,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.70 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3399,8 +3400,8 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.14.3"
+source = "git+https://github.com/near/sysinfo?rev=3cb97ee79a02754407d2f0f63628f247d7c65e7b#3cb97ee79a02754407d2f0f63628f247d7c65e7b"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "doc-comment 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3440,30 +3441,30 @@ dependencies = [
 [[package]]
 name = "testlib"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore#442998a79b9f9556c94aec2174eb858b31c0b4ee"
+source = "git+https://github.com/nearprotocol/nearcore?branch=stable#ebe21b338f17809b5ff6bc0ff2c0fbd5f5616bbb"
 dependencies = [
  "actix 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-chain 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-chain-configs 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-client 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-jsonrpc 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-jsonrpc-client 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-logger-utils 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-network 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-runtime-fees 0.9.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-store 0.1.0 (git+https://github.com/nearprotocol/nearcore)",
- "near-vm-errors 0.9.0 (git+https://github.com/nearprotocol/nearcore)",
- "neard 0.4.13 (git+https://github.com/nearprotocol/nearcore)",
- "node-runtime 0.9.0 (git+https://github.com/nearprotocol/nearcore)",
+ "near-chain 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-chain-configs 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-client 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-jsonrpc 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-jsonrpc-client 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-logger-utils 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-network 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-runtime-fees 0.9.1 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-store 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "near-vm-errors 0.9.1 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "neard 1.0.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
+ "node-runtime 0.9.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)",
  "num-rational 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4044,10 +4045,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum block-buffer 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dbcf92448676f82bb7a334c58bbce8b0d43580fb5362a9d608b18879d12a3d31"
 "checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 "checksum bn 0.4.4 (git+https://github.com/paritytech/bn)" = "<none>"
-"checksum borsh 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9dada4c07fa726bc195503048581e7b1719407f7fbef82741f7b149d3921b3"
-"checksum borsh-derive 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "47c6bed3dd7695230e85bd51b6a4e4e4dc7550c1974a79c11e98a8a055211a61"
-"checksum borsh-derive-internal 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d34f80970434cd6524ae676b277d024b87dd93ecdd3f53bf470d61730dc6cb80"
-"checksum borsh-schema-derive-internal 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3b93230d3769ea99ac75a8a7fee2a229defbc56fe8816c9cde8ed78c848aa33"
+"checksum borsh 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c7769f8f6fdc6ac7617bbc8bc7ef9dc263cd459d99d21cf2ab4afc3bc8d7d70d"
+"checksum borsh-derive 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d2689a82a5fe57f9e71997b16bea340da338c7fb8db400b8d9d55b59010540d8"
+"checksum borsh-derive-internal 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "39b621f19e9891a34f679034fa2238260e27c0eddfe2804e9fb282061cf9b294"
+"checksum borsh-schema-derive-internal 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "befebdb9e223ae4528b3d597dbbfb5c68566822d2a3de3e260f235360773ba29"
 "checksum brotli-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4445dea95f4c2b41cde57cc9fee236ae4dbae88d8fcbdb4750fc1bb5d86aaecd"
 "checksum brotli2 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0cb036c3eade309815c15ddbacec5b22c4d1f3983a774ab2eac2e3e9ea85568e"
 "checksum bs58 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "476e9cd489f9e121e02ffa6014a8ef220ecb15c05ed23fc34cca13925dc283fb"
@@ -4191,41 +4192,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum mio-uds 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum miow 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "22dfdd1d51b2639a5abd17ed07005c3af05fb7a2a3b1a1d0d7af1000a520c1c7"
-"checksum near-actix-utils 0.1.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
-"checksum near-chain 0.1.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
-"checksum near-chain-configs 0.1.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
-"checksum near-chunks 0.1.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
-"checksum near-client 0.1.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
-"checksum near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
-"checksum near-epoch-manager 0.0.1 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
-"checksum near-jsonrpc 0.1.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
-"checksum near-jsonrpc-client 0.1.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
-"checksum near-logger-utils 0.1.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
-"checksum near-metrics 0.1.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
-"checksum near-network 0.1.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
-"checksum near-pool 0.1.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
-"checksum near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
-"checksum near-rpc-error-core 0.1.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
+"checksum near-actix-utils 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)" = "<none>"
+"checksum near-chain 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)" = "<none>"
+"checksum near-chain-configs 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)" = "<none>"
+"checksum near-chunks 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)" = "<none>"
+"checksum near-client 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)" = "<none>"
+"checksum near-crypto 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)" = "<none>"
+"checksum near-epoch-manager 0.0.1 (git+https://github.com/nearprotocol/nearcore?branch=stable)" = "<none>"
+"checksum near-jsonrpc 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)" = "<none>"
+"checksum near-jsonrpc-client 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)" = "<none>"
+"checksum near-logger-utils 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)" = "<none>"
+"checksum near-metrics 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)" = "<none>"
+"checksum near-network 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)" = "<none>"
+"checksum near-pool 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)" = "<none>"
+"checksum near-primitives 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)" = "<none>"
+"checksum near-rpc-error-core 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)" = "<none>"
 "checksum near-rpc-error-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ffa8dbf8437a28ac40fcb85859ab0d0b8385013935b000c7a51ae79631dd74d9"
-"checksum near-rpc-error-macro 0.1.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
+"checksum near-rpc-error-macro 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)" = "<none>"
 "checksum near-rpc-error-macro 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0c6111d713e90c7c551dee937f4a06cb9ea2672243455a4454cc7566387ba2d9"
-"checksum near-runtime-configs 0.1.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
-"checksum near-runtime-fees 0.9.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
+"checksum near-runtime-configs 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)" = "<none>"
+"checksum near-runtime-fees 0.9.1 (git+https://github.com/nearprotocol/nearcore?branch=stable)" = "<none>"
 "checksum near-runtime-fees 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8f4992274c8acb33fa1246715d3aafbce5688ae82243c779b561f8eaff1bb6f1"
 "checksum near-sdk 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "81319d4d44283f63467e4f02b6209297b10643c7aeb62e2ee41e0c31b43e2375"
 "checksum near-sdk-core 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f3767fc2a61e6577f1336e06d6962a6c61fc39299573b8a25696fd09ce96ffb"
 "checksum near-sdk-macros 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "27c06b45c56028b0e1241b2196397d449091665f3f08d543415373505df5e05f"
-"checksum near-store 0.1.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
-"checksum near-telemetry 0.1.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
-"checksum near-vm-errors 0.9.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
+"checksum near-store 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)" = "<none>"
+"checksum near-telemetry 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)" = "<none>"
+"checksum near-vm-errors 0.9.1 (git+https://github.com/nearprotocol/nearcore?branch=stable)" = "<none>"
 "checksum near-vm-errors 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "386c2c07ef37ae52ad43860ef69c6322bbc1e610ae0c08c1d7f5ff56f4c28e6a"
-"checksum near-vm-logic 0.9.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
+"checksum near-vm-logic 0.9.1 (git+https://github.com/nearprotocol/nearcore?branch=stable)" = "<none>"
 "checksum near-vm-logic 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a6da6c80d3428f45248577820bfc943b8261a6f11d6721037e5c3f43484047cd"
-"checksum near-vm-runner 0.9.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
-"checksum neard 0.4.13 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
+"checksum near-vm-runner 0.9.1 (git+https://github.com/nearprotocol/nearcore?branch=stable)" = "<none>"
+"checksum neard 1.0.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)" = "<none>"
 "checksum net2 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)" = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 "checksum nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3b2e0b4f3320ed72aaedb9a5ac838690a8047c7b275da22711fddff4f8a14229"
-"checksum node-runtime 0.9.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
+"checksum node-runtime 0.9.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)" = "<none>"
 "checksum nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 "checksum nom 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b471253da97532da4b61552249c521e01e736071f71c1a4f7ebbfbf0a06aad6"
 "checksum ntapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7a31937dea023539c72ddae0e3571deadc1414b300483fa7aaec176168cfa9d2"
@@ -4302,7 +4303,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum resolv-conf 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "11834e137f3b14e309437a8276714eed3a80d1ef894869e510f2c0c0b98b9f4a"
 "checksum ripemd160 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7037e00ff78e861f53edd08ea4c4351fbf9b357145fdb791bc2f9a2236a33b45"
 "checksum rlp 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4a7d3f9bed94764eac15b8f14af59fac420c236adaff743b7bcc88e265cb4345"
-"checksum rocksdb 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "12069b106981c6103d3eab7dd1c86751482d0779a520b7c14954c8b586c1e643"
+"checksum rocksdb 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "61aa17a99a2413cd71c1106691bf59dad7de0cd5099127f90e9d99c429c40d4a"
 "checksum rust-argon2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
@@ -4345,11 +4346,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)" = "95b5f192649e48a5302a13f2feb224df883b98933222369e4b3b0fe2a5447269"
 "checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
-"checksum sysinfo 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "70bbf8e10fc10b83e71bc19f4374ce17209d45c7c4c99b5067ac554aba3bfd08"
+"checksum sysinfo 0.14.3 (git+https://github.com/near/sysinfo?rev=3cb97ee79a02754407d2f0f63628f247d7c65e7b)" = "<none>"
 "checksum target-lexicon 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ab0e7238dcc7b40a7be719a25365910f6807bd864f4cce6b2e6b873658e2b19d"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
-"checksum testlib 0.1.0 (git+https://github.com/nearprotocol/nearcore)" = "<none>"
+"checksum testlib 0.1.0 (git+https://github.com/nearprotocol/nearcore?branch=stable)" = "<none>"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thiserror 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5976891d6950b4f68477850b5b9e5aa64d955961466f9e174363f573e54e8ca7"
 "checksum thiserror-impl 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "ab81dbd1cd69cd2ce22ecfbdd3bdb73334ba25350649408cc6c085f46d89573d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 hex = "0.3.2"
 near-sdk = "0.11.0"
-borsh = "0.6.0"
+borsh = "^0.6.2"
 rlp = "0.4.2"
 keccak-hash = "0.2.0"
 num-bigint = { version = "0.3", default-features = false }
@@ -32,10 +32,10 @@ ethabi = "8.0.0"
 ethabi-contract = "8.0.0"
 ethabi-derive = "8.0.0"
 protobuf = "2.4"
-near-jsonrpc-client = { git = "https://github.com/nearprotocol/nearcore", branch = "master" }
-near-primitives = { git = "https://github.com/nearprotocol/nearcore", branch = "master" }
-near-crypto = { git = "https://github.com/nearprotocol/nearcore", branch = "master" }
-near-testlib = { git = "https://github.com/nearprotocol/nearcore", branch = "master", package = "testlib" }
+near-jsonrpc-client = { git = "https://github.com/nearprotocol/nearcore", branch = "stable" }
+near-primitives = { git = "https://github.com/nearprotocol/nearcore", branch = "stable" }
+near-crypto = { git = "https://github.com/nearprotocol/nearcore", branch = "stable" }
+near-testlib = { git = "https://github.com/nearprotocol/nearcore", branch = "stable", package = "testlib" }
 actix = "0.9"
 futures = "0.3"
 lazy-static-include = "2.2.2"


### PR DESCRIPTION
Even with these updates I still get the following error. It seemed to start happening out of nowhere, I'm wondering if it could be environment specific to my machine....but I don't think so...

```bash
# start nearcore mockblockchain from nearcore directory
python scripts/start_unittest.py --local --release

# build updated near-evm
cargo +stable build --target wasm32-unknown-unknown --release
./build.sh

# build test contracts
cd src/tests && ./build.sh && cd ../..

# run test
cargo test test_all -- --show-output

failures:

---- test_all_in_one stdout ----
Deploying evm contract
thread 'test_all_in_one' panicked at 'called `Result::unwrap()` on an `Err` value: Error("unknown variant `Error SyntaxError(\"EOF while parsing a value at line 1 column 0\") in b\"\"`, expected one of `TxExecutionError`, `Timeout`, `Closed`, `InternalError`", line: 0, column: 0)', /Users/emilywilliams/.cargo/git/checkouts/nearcore-e3f14b9758bedfa0/ebe21b3/test-utils/testlib/src/user/rpc_user.rs:96:29
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```