### PR TITLE
Add ecrecover alias map to evm contract

### DIFF
--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -53,7 +53,7 @@ pub fn process_precompile(ctx: &NearExt, addr: &Address, input: &[u8]) -> Messag
     // hijack ECDSA calls
     if addr.to_low_u64_be() == 1 {
         let produced = Address::from_slice(&bytes[12..]);
-        if let Some(addr) = ctx.sub_state.ecdsa_map_get(produced) {
+        if let Some(addr) = ctx.sub_state.get_ecrecover_alias(produced) {
             bytes.clear();
             bytes.extend(&[0; 12]);
             bytes.extend(&addr[..]);

--- a/src/evm_state.rs
+++ b/src/evm_state.rs
@@ -5,6 +5,8 @@ use ethereum_types::{Address, U256};
 use crate::utils;
 
 pub trait EvmState {
+    fn ecdsa_map_get(&self, address: Address) -> Option<Address>;
+
     fn code_at(&self, address: &Address) -> Option<Vec<u8>>;
     fn set_code(&mut self, address: &Address, bytecode: &[u8]);
 
@@ -150,6 +152,10 @@ impl StateStore {
 }
 
 impl EvmState for StateStore {
+    fn ecdsa_map_get(&self, _address: Address) -> Option<Address> {
+        None
+    }
+
     fn code_at(&self, address: &Address) -> Option<Vec<u8>> {
         let internal_addr = utils::evm_account_to_internal_address(*address);
         if self.self_destructs.contains(&internal_addr) {
@@ -231,6 +237,10 @@ impl SubState<'_> {
 }
 
 impl EvmState for SubState<'_> {
+    fn ecdsa_map_get(&self, address: Address) -> Option<Address> {
+        self.parent.ecdsa_map_get(address)
+    }
+
     fn code_at(&self, address: &Address) -> Option<Vec<u8>> {
         let internal_addr = utils::evm_account_to_internal_address(*address);
         if self.state.self_destructs.contains(&internal_addr) {

--- a/src/evm_state.rs
+++ b/src/evm_state.rs
@@ -5,7 +5,7 @@ use ethereum_types::{Address, U256};
 use crate::utils;
 
 pub trait EvmState {
-    fn ecdsa_map_get(&self, address: Address) -> Option<Address>;
+    fn get_ecrecover_alias(&self, address: Address) -> Option<Address>;
 
     fn code_at(&self, address: &Address) -> Option<Vec<u8>>;
     fn set_code(&mut self, address: &Address, bytecode: &[u8]);
@@ -152,7 +152,7 @@ impl StateStore {
 }
 
 impl EvmState for StateStore {
-    fn ecdsa_map_get(&self, _address: Address) -> Option<Address> {
+    fn get_ecrecover_alias(&self, _address: Address) -> Option<Address> {
         None
     }
 
@@ -237,8 +237,8 @@ impl SubState<'_> {
 }
 
 impl EvmState for SubState<'_> {
-    fn ecdsa_map_get(&self, address: Address) -> Option<Address> {
-        self.parent.ecdsa_map_get(address)
+    fn get_ecrecover_alias(&self, address: Address) -> Option<Address> {
+        self.parent.get_ecrecover_alias(address)
     }
 
     fn code_at(&self, address: &Address) -> Option<Vec<u8>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,19 @@ mod near_ext;
 pub mod utils;
 
 /// Represents the state of the EVM. All NearMaps are persisted to Near chain storage
+///
+/// The EVM contract public interface. Generally, the EVM handles ethereum-style 20-byte
+/// hex-encoded addresses. External Near accountIDs are converted to EVM addresses by hashing
+/// them, and taking the final 20 bytes of the hash. Which is to say, they roughly correspond to
+/// Ethereum's externally-owned-account public keys.
+///
+/// The EVM holds NEAR and keeps an internal balances mapping to all EVM accounts. Therefore EVM
+/// contracts can hold NEAR and interact with it.
+///
+/// # Note:
+///
+/// Logs are mapped to a byte vector by Length-prepending the topics and then appending the data.
+/// E.g. an event with 3 topics will be serialized as `0x03[topic1][topic2][topic3][data]`.
 #[near_bindgen_macro]
 #[derive(BorshDeserialize, BorshSerialize, Default)]
 pub struct EvmContract {
@@ -101,13 +114,6 @@ impl EvmState for EvmContract {
     }
 }
 
-/// The EVM contract public interface. Generally, the EVM handles ethereum-style 20-byte
-/// hex-encoded addresses. External Near accountIDs are converted to EVM addresses by hashing
-/// them, and taking the final 20 bytes of the hash. Which is to say, they roughly correspond to
-/// Ethereum's externally-owned-account public keys.
-///
-/// The EVM holds NEAR and keeps an internal balances mapping to all EVM accounts. Therefore EVM
-/// contracts can hold NEAR and interact with it.
 #[near_bindgen_macro]
 impl EvmContract {
     /// Returns the storage at a particular slot, as a hex-encoded. Slots are 32-bytes wide,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -398,11 +398,13 @@ impl EvmContract {
         let mut message = format!("\x19Ethereum Signed Message:\n{}", body.len());
         message.push_str(&body);
 
+
         let signature_bytes = hex::decode(&signature).expect("valid hex input");
         let signature_bytes = utils::parse_rsv(&signature_bytes);
 
+        // ecrecover expects digest, v, r, s to be 32 bytes each.
         let mut ecdsa_input = vec![];
-        ecdsa_input.extend(keccak_hash::keccak(message).as_bytes());
+        ecdsa_input.extend(keccak_hash::keccak(&message).as_bytes());
         ecdsa_input.extend(&signature_bytes[..]);
 
         let mut output = vec![];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,6 +367,9 @@ impl EvmContract {
     /// use EcRecover to seamlessly use Ethereum metatransactions and other signature-driven
     /// features without integrating Near's signature scheme into the Near-EVM.
     ///
+    /// Users may register multiple aliases, which are all effective. Users currently cannot
+    /// revoke aliases.
+    ///
     /// To register an alias, the key must sign the Near-EVM address, AND the Near account
     /// corresponding to that address must submit the signature. This prevents replay attacks,
     /// and registering keys that are not actually controlled by the Near account holder.
@@ -393,7 +396,7 @@ impl EvmContract {
     ///
     /// * When `signature` is not valid hex.
     /// * When the signature is invalid.
-    pub fn register_ecdsa_alias(&mut self, signature: String) {
+    pub fn register_ecdsa_alias(&mut self, signature: String) -> bool {
         let body = format!("Near ecrecover alias: {}", env::predecessor_account_id());
         let mut message = format!("\x19Ethereum Signed Message:\n{}", body.len());
         message.push_str(&body);
@@ -420,6 +423,7 @@ impl EvmContract {
             &Address::from_slice(&output[12..32]),
             &utils::predecessor_as_evm(),
         );
+        true
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,10 +361,32 @@ impl EvmContract {
         utils::u256_to_balance(&self.nonce_of(&addr))
     }
 
-    pub fn register_ecdsa_alisa(&mut self, signature: String) {
+
+    /// Register an ECDSA alias. This is an ECDSA key that is allowed to make updates and sign
+    /// messages on behalf of your Near-EVM account. This allows Near-EVM contracts to effectively
+    /// use EcRecover to seamlessly use Ethereum metatransactions and other signature-driven
+    /// features without integrating Near's signature scheme into the Near-EVM.
+    ///
+    /// To register an alias, the key must sign the Near-EVM address, AND the Near account
+    /// corresponding to that address must submit the signature. This prevents replay attacks,
+    /// and registering keys that are not actually controlled by the Near account holder.
+    ///
+    /// The message format uses the standard `Ethereum Signed Message` format, and can be produced
+    /// by `eth_sign` or `eth_signPersonal`. The body of the message is the hex of the address
+    /// (without the "0x" prefix). This creates a message length of 40 bytes (20 bytes, encoded as
+    /// a hex) string.
+    ///
+    /// # Arguments
+    ///
+    /// * `signature` - a valid ethereum-formatted signature
+    ///
+    /// # Panics
+    ///
+    /// * When `signature` is not valid hex.
+    pub fn register_ecdsa_alias(&mut self, signature: String) {
         let target = utils::predecessor_as_evm();
-        let mut message = format!("\x19Ethereum Signed Message:\n{}", 20).into_bytes();
-        message.extend(target.as_bytes());
+        let mut message = format!("\x19Ethereum Signed Message:\n{}", 40).into_bytes();
+        message.extend(target.to_string().as_bytes());
 
         let signature_bytes = hex::decode(&signature).expect("valid hex input");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub struct EvmContract {
     balances: NearMap<Vec<u8>, [u8; 32]>,
     nonces: NearMap<Vec<u8>, [u8; 32]>,
     storages: NearTreeMap<Vec<u8>, [u8; 32]>,
+    ecrecover_aliases: NearMap<Vec<u8>, [u8; 32]>,
 }
 
 #[ext_contract]
@@ -42,6 +43,10 @@ pub trait Callback {
 }
 
 impl EvmState for EvmContract {
+    fn ecdsa_map_get(&self, address: Address) -> Option<Address> {
+        self.ecrecover_aliases.get(&address[..].to_vec()).map(|a| Address::from_slice(&a[12..]))
+    }
+
     // Default code of None
     fn code_at(&self, address: &Address) -> Option<Vec<u8>> {
         let internal_addr = utils::evm_account_to_internal_address(*address);

--- a/src/near_ext.rs
+++ b/src/near_ext.rs
@@ -175,7 +175,7 @@ impl<'a> vm::Ext for NearExt<'a> {
 
         // hijack builtins
         if crate::builtins::is_precompile(receive_address) {
-            return Ok(crate::builtins::process_precompile(receive_address, data));
+            return Ok(crate::builtins::process_precompile(self, receive_address, data));
         }
 
         let result = match call_type {

--- a/src/near_ext.rs
+++ b/src/near_ext.rs
@@ -259,10 +259,18 @@ impl<'a> vm::Ext for NearExt<'a> {
     }
 
     /// Creates log entry with given topics and data
-    fn log(&mut self, _topics: Vec<H256>, data: &[u8]) -> EvmResult<()> {
+    fn log(&mut self, topics: Vec<H256>, data: &[u8]) -> EvmResult<()> {
         if self.is_static() {
             return Err(VmError::MutableCallInStaticContext);
         }
+
+        let mut payload = vec![];
+        payload.push(topics.len() as u8);
+        for topic in topics.iter() {
+            payload.extend(topic.as_ref());
+        }
+        payload.extend(data);
+
 
         // TODO: Develop a NearCall logspec
         //       hijack NearCall logs here
@@ -270,7 +278,7 @@ impl<'a> vm::Ext for NearExt<'a> {
         //       return them after execution completes
         //       dispatch promises
 
-        self.sub_state.state.logs.push(hex::encode(data));
+        self.sub_state.state.logs.push(hex::encode(payload));
         Ok(())
     }
 

--- a/src/tests/contracts/SolTests.sol
+++ b/src/tests/contracts/SolTests.sol
@@ -57,6 +57,10 @@ contract SolTests is ExposesBalance {
             "ecrecover mismatch"
         );
     }
+
+    function ecdsaRecovery(bytes32 digest, uint8 v, bytes32 r, bytes32 s) public pure returns (address) {
+        return ecrecover(digest, v, r, s);
+    }
 }
 
 contract SubContract is ExposesBalance {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -16,6 +16,16 @@ lazy_static_include_str!(DESTRUCT_TEST, "src/tests/build/SelfDestruct.bin");
 lazy_static_include_str!(CONSTRUCTOR_TEST, "src/tests/build/ConstructorRevert.bin");
 
 #[test]
+fn test_register_ecdsa_key() {
+    // produced by James's metamask
+    // window.ethereum.sendAsync({method: "personal_sign", params: ["Near ecrecover alias: owner1", "0x5cd08940869f68a891756e51269aa27e54e8c4df"]}, console.log)
+    let sig_hex = "6caed388392227b043d47f2fde914ffe290f44475ce201b3002206c954b2e30a4790c1cc7a38838862ecb0b7f62852fa8e4882452ba8de9b65a6c9cef8187dd31b";
+
+    let mut contract = test_utils::initialize();
+    contract.register_ecdsa_alias(sig_hex.to_owned());
+}
+
+#[test]
 fn test_sends() {
     let mut contract = test_utils::initialize();
     let evm_acc = hex::encode(utils::near_account_id_to_evm_address("evmGuy").0);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -138,3 +138,27 @@ impl From<Balance> for u128 {
         balance.0
     }
 }
+
+
+pub fn parse_rsv(rsv_sig: &[u8]) -> [u8; 96] {
+    assert!(rsv_sig.len() > 64, "Too short to be an rsv");
+    let v_len = rsv_sig.len() - 64;
+
+    let mut output = [0u8; 96];
+    output[32 - v_len..32].copy_from_slice(&rsv_sig[64..]);
+    output[32..64].copy_from_slice(&rsv_sig[..32]);
+    output[64..].copy_from_slice(&rsv_sig[32..64]);
+    output
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn it_parses_rsv_sigs() {
+        let sig = hex::decode("6caed388392227b043d47f2fde914ffe290f44475ce201b3002206c954b2e30a4790c1cc7a38838862ecb0b7f62852fa8e4882452ba8de9b65a6c9cef8187dd31b").unwrap();
+        let parsed = parse_rsv(&sig);
+        assert_eq!(&parsed[32..], &sig[..64]);
+        assert_eq!(parsed[31], sig[64]);
+    }
+}


### PR DESCRIPTION
supersedes #28 by integrating the logic directly into the contract

See this comment for rationale: https://github.com/near/near-evm/pull/28#issuecomment-645544390

# TODOs
- [x] add method for registering alias
- [x] improve protocol binding
- [x] tests of registration and aliasing
- [ ] blocked by https://github.com/nearprotocol/nearcore/issues/2939 