### PR TITLE
Log topics

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,19 @@ mod near_ext;
 pub mod utils;
 
 /// Represents the state of the EVM. All NearMaps are persisted to Near chain storage
+///
+/// The EVM contract public interface. Generally, the EVM handles ethereum-style 20-byte
+/// hex-encoded addresses. External Near accountIDs are converted to EVM addresses by hashing
+/// them, and taking the final 20 bytes of the hash. Which is to say, they roughly correspond to
+/// Ethereum's externally-owned-account public keys.
+///
+/// The EVM holds NEAR and keeps an internal balances mapping to all EVM accounts. Therefore EVM
+/// contracts can hold NEAR and interact with it.
+///
+/// # Note:
+///
+/// Logs are mapped to a byte vector by Length-prepending the topics and then appending the data.
+/// E.g. an event with 3 topics will be serialized as `0x03[topic1][topic2][topic3][data]`.
 #[near_bindgen_macro]
 #[derive(BorshDeserialize, BorshSerialize, Default)]
 pub struct EvmContract {
@@ -101,13 +114,6 @@ impl EvmState for EvmContract {
     }
 }
 
-/// The EVM contract public interface. Generally, the EVM handles ethereum-style 20-byte
-/// hex-encoded addresses. External Near accountIDs are converted to EVM addresses by hashing
-/// them, and taking the final 20 bytes of the hash. Which is to say, they roughly correspond to
-/// Ethereum's externally-owned-account public keys.
-///
-/// The EVM holds NEAR and keeps an internal balances mapping to all EVM accounts. Therefore EVM
-/// contracts can hold NEAR and interact with it.
 #[near_bindgen_macro]
 impl EvmContract {
     /// Returns the storage at a particular slot, as a hex-encoded. Slots are 32-bytes wide,

--- a/src/near_ext.rs
+++ b/src/near_ext.rs
@@ -259,10 +259,18 @@ impl<'a> vm::Ext for NearExt<'a> {
     }
 
     /// Creates log entry with given topics and data
-    fn log(&mut self, _topics: Vec<H256>, data: &[u8]) -> EvmResult<()> {
+    fn log(&mut self, topics: Vec<H256>, data: &[u8]) -> EvmResult<()> {
         if self.is_static() {
             return Err(VmError::MutableCallInStaticContext);
         }
+
+        let mut payload = vec![];
+        payload.push(topics.len() as u8);
+        for topic in topics.iter() {
+            payload.extend(topic.as_ref());
+        }
+        payload.extend(data);
+
 
         // TODO: Develop a NearCall logspec
         //       hijack NearCall logs here
@@ -270,7 +278,7 @@ impl<'a> vm::Ext for NearExt<'a> {
         //       return them after execution completes
         //       dispatch promises
 
-        self.sub_state.state.logs.push(hex::encode(data));
+        self.sub_state.state.logs.push(hex::encode(payload));
         Ok(())
     }
 


### PR DESCRIPTION
Log topics were being dropped instead of logged. This PR changes that behavior to ensure logs get. It significantly changes the way logs are output.

Logs are mapped to a byte vector by Length-prepending the topics and then appending the data.
E.g. an event with 3 topics will be serialized as `0x03[topic1][topic2][topic3][data]`.

Translating from this format should be done as follows
1. Read the first byte of the log `n`
2. Read `n` 32-byte segments. These are the topics in order.
3. The remainder is the log data.