### PR TITLE
Update build.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ To develop Rust contracts you would need to:
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
-2. Add a WebAssembly target to your Rust toolchain:
+2. cd into root dir of this repo, add a WebAssembly target to your Rust toolchain:
 ```bash
-rustup target add wasm32-unknown-unknown --toolchain stable
+rustup target add wasm32-unknown-unknown
 ```
 
 ### Building

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-RUSTFLAGS='-C link-arg=-s' cargo +nightly build -p near-evm --lib --target wasm32-unknown-unknown --release --no-default-features --features=contract -Z avoid-dev-deps || exit 1
+RUSTFLAGS='-C link-arg=-s' cargo build -p near-evm --lib --target wasm32-unknown-unknown --release --no-default-features --features=contract -Z avoid-dev-deps || exit 1
 mkdir -p res
 cp target/wasm32-unknown-unknown/release/near_evm.wasm ./res/
 


### PR DESCRIPTION
+nightly would use latest nightly, however `rustup target add wasm32-unknown-unknown` would add wasm32 target for rust nightly as in `rust-toolchain`, therefore latest nightly still doesn't have wasm32 target and result in build error. Before this fix i was always failed to build with error:
```
error[E0463]: can't find crate for `core`
  |
  = note: the `wasm32-unknown-unknown` target may not be installed
```
