### PR TITLE
feat: add methods enum

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,31 @@ mod contract {
         }
     }
 
+    pub enum Methods {
+        DeployCode,
+        Call,
+        View,
+        GetCode,
+        GetBalance,
+        GetNonce,
+        GetStorageAt,
+    }
+
+    impl ToString for Methods {
+        fn to_string(&self) -> String {
+            use Methods::*;
+            match self {
+                DeployCode => "deploy_code".to_string(),
+                Call => "call".to_string(),
+                View => "view".to_string(),
+                GetCode => "get_code".to_string(),
+                GetBalance => "get_balance".to_string(),
+                GetNonce => "get_nonce".to_string(),
+                GetStorageAt => "get_storage_at".to_string(),
+            }
+        }
+    }
+
     #[no_mangle]
     pub extern "C" fn deploy_code() {
         let input = sdk::read_input();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,13 +64,24 @@ mod contract {
         }
     }
 
+    /// All available methods available for the EVM contract.
+    ///
+    /// This makes it easier to get the correct method strings to use when using
+    /// the library.
     pub enum Methods {
+        /// "deploy_code"
         DeployCode,
+        /// "call"
         Call,
+        /// "view"
         View,
+        /// "get_code"
         GetCode,
+        /// "get_balance"
         GetBalance,
+        /// "get_nonce"
         GetNonce,
+        /// "get_storage_at"
         GetStorageAt,
     }
 


### PR DESCRIPTION
While doing the tests, this made quite a bit of sense to easily get a list of available methods without actually having to look at the code itself and potentially get confused that the method names themselves should be input as strings. This makes that distinction clearer and should remove some uncertainty from users of the library.